### PR TITLE
Added `build-essential` package needed for compiling native _node_ packages.

### DIFF
--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -11,6 +11,7 @@ DEV_PACKAGES:
     - openssl
     - g++
     - make
+    - build-essential
     - postgresql
     - postgresql-contrib
     - python-psycopg2


### PR DESCRIPTION
As notes [here](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions), the `build-essential` debian packages needs to be present to build native dependencies. An example of this within troposphere's `package.json` would be `node-sass`. 

This is currently working on the dev build server because this package is **already** present.