### PR TITLE
Change `pip install` module to use dev requirements for troposphere

### DIFF
--- a/roles/troposphere-setup-troposphere/tasks/main.yml
+++ b/roles/troposphere-setup-troposphere/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: pip install requirements
-  pip: requirements={{ TROPOSPHERE_LOCATION }}/requirements.txt virtualenv={{ VIRTUAL_ENV_TROPOSPHERE }}
+  pip: requirements={{ TROPOSPHERE_LOCATION }}/dev_requirements.txt virtualenv={{ VIRTUAL_ENV_TROPOSPHERE }}
 
 - name: create troposphere log directory
   command: mkdir -p {{ TROPOSPHERE_LOCATION }}/logs


### PR DESCRIPTION
For now, we will force builds & deployments to install all dependencies.

Choosing between `requirements.txt` & `dev_requirements.txt` would be an
enhancements for the over tool. This would likely be controlled by the master
`variables.yml` file (or a more Ansible-like approach).

**Note:** this only _affects_ the `deploy_troposphere` playbook's task. 