### PR TITLE
Change the `pip` module to request latest as `state`.

### DIFF
--- a/roles/troposphere-setup-troposphere/tasks/main.yml
+++ b/roles/troposphere-setup-troposphere/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: pip install requirements
-  pip: requirements={{ TROPOSPHERE_LOCATION }}/dev_requirements.txt virtualenv={{ VIRTUAL_ENV_TROPOSPHERE }}
+  pip: requirements={{ TROPOSPHERE_LOCATION }}/dev_requirements.txt virtualenv={{ VIRTUAL_ENV_TROPOSPHERE }}  state=latest
 
 - name: create troposphere log directory
   command: mkdir -p {{ TROPOSPHERE_LOCATION }}/logs


### PR DESCRIPTION
With assistance from Matt Deporter, we triaged the problem of "stale" playbook/role execution on the build server. It appeared that the `state=latest` needed to be added to the role using the `pip` module. Adding this provided as successful run within a clean, isolated workspace directory. 

