### PR TITLE
Changed repo check to use `.git` to ensure a repo is present.

### DIFF
--- a/roles/atmosphere-clone-repo/tasks/main.yml
+++ b/roles/atmosphere-clone-repo/tasks/main.yml
@@ -4,7 +4,7 @@
     - ansible-deploy
 
 - name: check to see if repo exists
-  stat: path={{ ATMOSPHERE_LOCATION }}
+  stat: path={{ ATMOSPHERE_LOCATION }}/.git
   register: p
   tags:
     - ansible-deploy
@@ -14,6 +14,7 @@
   when: p.stat.exists == false
   tags:
     - ansible-deploy
+
 # include pull.yml when the repo does exists
 - include: pull.yml
   when: p.stat.exists

--- a/roles/troposphere-clone-repo/tasks/main.yml
+++ b/roles/troposphere-clone-repo/tasks/main.yml
@@ -2,7 +2,7 @@
   command: mkdir -p "{{ TROPOSPHERE_DIR }}"
 
 - name: check to see if repo exists
-  stat: path={{ TROPOSPHERE_LOCATION }}
+  stat: path={{ TROPOSPHERE_LOCATION }}/.git
   register: p
 
 # include clone.yml when the repo does not exist


### PR DESCRIPTION
This used the assumption that a git repository *has* to have a `.git` to be valid. So here, we just tack it onto the location used within `stat` module. 

**Refactor note:** - it looks like all pulling/cloning _roles_ could be factored out from the "troposphere-*-repo", "atmosphere-*-repo", & "atmo-ansible-*-repo" into generalized tasks.