### PR TITLE
Cleanup _clone_ tasks within troposphere setup role.

### DIFF
--- a/roles/troposphere-clone-repo/tasks/clone.yml
+++ b/roles/troposphere-clone-repo/tasks/clone.yml
@@ -1,5 +1,3 @@
-- debug: msg="IN THE CLONE FILE"
-
 - name: ensure troposphere location
   command: mkdir -p {{ TROPOSPHERE_LOCATION }}
 

--- a/roles/troposphere-clone-repo/tasks/clone.yml
+++ b/roles/troposphere-clone-repo/tasks/clone.yml
@@ -15,20 +15,3 @@
        update=yes
        version={{ TROPOSPHERE_BRANCH | default("master") }}
   when: TROPOSPHERE_BRANCH |length > 0
-
-- name: clone local temp troposphere git repo
-  local_action: >
-       git repo=https://github.com/iPlantCollaborativeOpenSource/troposphere.git
-       dest=/tmp/troposphere
-       clone=yes
-       update=yes
-  when: TROPOSPHERE_BRANCH |length == 0  
-
-- name: clone local troposphere git repo with branched defined
-  local_action: >
-       git repo=https://github.com/iPlantCollaborativeOpenSource/troposphere.git
-       dest=/tmp/troposphere
-       clone=yes
-       update=yes
-       version={{ TROPOSPHERE_BRANCH | default("master") }}
-  when: TROPOSPHERE_BRANCH |length > 0


### PR DESCRIPTION
These _local_ clone tasks were not being used and can we removed. 
