### PR TITLE
Remove apache2 from install dependency consideration.

### DIFF
--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -40,14 +40,6 @@ LIB_PACKAGES:
     - zlib1g-dev
   state: latest
 
-APACHE_PACKAGES:
-  packages:
-    - apache2 
-    - libapache2-mod-auth-cas 
-    - libapache2-mod-wsgi 
-    - libapache2-mod-macro
-  state: latest
-
 NGINX_PACKAGES:
   packages:
     - uwsgi


### PR DESCRIPTION
The block of packages under `APACHE_PACKAGES` is never used within the `install-dependencies` role. Remove, as unused. 

_Also..._
 
Neither atmosphere nor troposphere will be actively supported by the team running in a configuration with _apache2 + mod_wsgi_ given previous issue encountered while using apache in production. We offer a Python source-level notion that running the application with _such_ a configuration is *possible* but not one we will actively support. As such, we should begin removing apache configurations from clank, atmosphere, & troposphere repositories. 

This is per approval from @steve-gregory. If I have misunderstood, we can definitely close this PR.