### PR TITLE
Add bash aliases for atmo and tropo to test new Ansible 2.0 modules

### DIFF
--- a/roles/atmosphere-setup-atmosphere/tasks/main.yml
+++ b/roles/atmosphere-setup-atmosphere/tasks/main.yml
@@ -7,6 +7,18 @@
     - "{{ ansible_os_family }}.yml"
   tags: vars
 
+- name: template out atmo bash aliases
+  template: src=atmo_bash_aliases.j2 dest=~/.atmo_bash_aliases mode="u=rw,g=r,o=r"
+
+- name: add atmo bash aliases to ~/.bashrc
+  blockinfile:
+    dest: ~/.bashrc
+    block: |
+      if [ -f ~/.atmo_bash_aliases ]; then
+        . ~/.atmo_bash_aliases
+      fi
+    marker: "# {mark} ANSIBLE MANAGED BLOCK atmo_bash_aliases"
+    
 - name: install dev packages packages
   action: >
     {{ ansible_pkg_mgr }} name={{ item }} state={{ DEV_PACKAGES.state }}

--- a/roles/atmosphere-setup-atmosphere/templates/atmo_bash_aliases.j2
+++ b/roles/atmosphere-setup-atmosphere/templates/atmo_bash_aliases.j2
@@ -1,0 +1,7 @@
+# Managed by Ansible
+
+alias atmoactivate='source {{ VIRTUAL_ENV_ATMOSPHERE }}/bin/activate'
+alias atmocd='atmoactivate;cd {{ ATMOSPHERE_LOCATION }}'
+alias atmoacd='cd {{ ANSIBLE_DEPLOY_LOCATION }}'
+alias atmomanage='atmocd;DJANGO_SETTINGS_MODULE='\''atmosphere.settings'\'' {{ ATMOSPHERE_LOCATION }}/manage.py'
+alias atmor='service atmosphere celery-restart'

--- a/roles/troposphere-setup-troposphere/tasks/main.yml
+++ b/roles/troposphere-setup-troposphere/tasks/main.yml
@@ -7,6 +7,18 @@
     - "defaults.yml"
   tags: vars
 
+- name: template out tropo bash aliases
+  template: src=tropo_bash_aliases.j2 dest=~/.tropo_bash_aliases mode="u=rw,g=r,o=r"
+
+- name: add aliases to ~/.bashrc
+  blockinfile:
+    dest: ~/.bashrc
+    block: |
+      if [ -f ~/.tropo_bash_aliases ]; then
+        . ~/.tropo_bash_aliases
+      fi
+    marker: "# {mark} ANSIBLE MANAGED BLOCK tropo_bash_aliases"
+
 - name: troposphere database is created
   become: yes
   become_user: postgres

--- a/roles/troposphere-setup-troposphere/templates/tropo_bash_aliases.j2
+++ b/roles/troposphere-setup-troposphere/templates/tropo_bash_aliases.j2
@@ -1,0 +1,6 @@
+# Managed by Ansible
+
+alias tropoactivate='source {{ VIRTUAL_ENV_TROPOSPHERE }}/bin/activate'
+alias tropocd='tropoactivate;cd {{ TROPOSPHERE_LOCATION }}'
+alias tropomanage='tropocd;DJANGO_SETTINGS_MODULE='\''troposphere.settings'\'' {{ TROPOSPHERE_LOCATION }}/manage.py'
+alias tropor='service troposphere celery-restart'


### PR DESCRIPTION
Added a simple feature to ensure that the new Ansible 2.0 were available to us.