### PR TITLE
Configure-able Atmosphere deployment

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -17,6 +17,8 @@ ATMOSPHERE_BRANCH: ""
 # ATMO ANSIBLE
 ANSIBLE_DEPLOY_DIR: "{{ ATMOSPHERE_DIR }}"
 ANSIBLE_DEPLOY_LOCATION: "{{ ANSIBLE_DEPLOY_DIR }}/atmosphere-ansible"
+# Placeholder for defining the atmosphere-ansible branch:
+ANSIBLE_DEPLOY_BRANCH: ""
 ANSIBLE_REPO: https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible.git
 
 # TROPO

--- a/roles/app-install-instance-deploy-automation/tasks/main.yml
+++ b/roles/app-install-instance-deploy-automation/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
 # tasks file for app-install-instance-deploy-automation
 
-- name: insert ansible role path into config file
-  lineinfile: >
-    dest={{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/ansible.cfg
-    regexp="roles_path ="
-    line="roles_path = {{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/roles"
+- name: run configuration for atmosphere-ansible
+  shell: "{{ VIRTUAL_ENV_ATMOSPHERE }}/bin/python {{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/configure"
+  register: output
+
+- debug: var=output.stdout_lines
+  when: "{{ CLANK_VERBOSE | default(False) }}"
 
 - name: make ssh file directory
   file: path={{ APP_BASE_DIR }}/extras/ssh/ state=directory

--- a/roles/atmosphere-clone-repo/tasks/main.yml
+++ b/roles/atmosphere-clone-repo/tasks/main.yml
@@ -31,13 +31,23 @@
 - name: ensure ansible role location
   file: path={{ ANSIBLE_DEPLOY_LOCATION }} state=directory
 
-- name: clone ansible git repo
+- name: clone ansible deploy git repo
   git: repo={{ ANSIBLE_REPO }}
        dest={{ ANSIBLE_DEPLOY_LOCATION }}
        clone=yes
        update=yes
        force=yes
-       version="master"
+       version={{ ANSIBLE_DEPLOY_BRANCH | default("master") }}
+  when: (ANSIBLE_DEPLOY_BRANCH |length == 0 and not p.stat.exists)
+
+- name: clone ansible deploy git repo with branched defined
+  git: repo={{ ANSIBLE_REPO }}
+       dest={{ ANSIBLE_DEPLOY_LOCATION }}
+       clone=yes
+       update=yes
+       version={{ ANSIBLE_DEPLOY_BRANCH | default("master") }}
+  when: (ANSIBLE_DEPLOY_BRANCH |length > 0 and not p.stat.exists)
+
   tags:
     - ansible-deploy
   when: not p.stat.exists


### PR DESCRIPTION
To be included after merging Atmosphere/subspace/atmosphere-ansible branches: https://github.com/iPlantCollaborativeOpenSource/subspace/pull/2

This will allow clank to select a specific branch of atmosphere-ansible and configure the deployment, rather than use ansible's line in file.