### PR TITLE
Make ssl certs and ssh key creation the default

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -18,6 +18,8 @@ ATMOSPHERE_BRANCH: ""
 ANSIBLE_DEPLOY_DIR: "{{ ATMOSPHERE_DIR }}"
 ANSIBLE_DEPLOY_LOCATION: "{{ ANSIBLE_DEPLOY_DIR }}/atmosphere-ansible"
 ANSIBLE_REPO: https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible.git
+# Placeholder for defining the atmosphere-ansible branch:
+ATMOSPHERE_ANSIBLE_BRANCH: ""
 
 # TROPO
 VIRTUAL_ENV_DIR_TROPOSPHERE: /opt/env

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -18,6 +18,16 @@
         when: clean_target,
         tags: ['dependencies', 'ssl'] }
 
+- name: Clone Atmosphere Ansible
+  hosts: all
+
+  roles:
+    - { role: clone-repo,
+        REPO_BASE_DIR: "{{ ANSIBLE_DEPLOY_DIR }}",
+        CLONE_TARGET: "{{ ANSIBLE_DEPLOY_LOCATION }}",
+        REPO_URI: "{{ ANSIBLE_REPO }}",
+        tags: [ 'atmosphere', 'clone-repo'] }
+
 - name: Setup virtualenv and clone Atmosphere
   hosts: all
 

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -25,6 +25,7 @@
     - { role: clone-repo,
         REPO_BASE_DIR: "{{ ANSIBLE_DEPLOY_DIR }}",
         CLONE_TARGET: "{{ ANSIBLE_DEPLOY_LOCATION }}",
+        SPECIFIC_BRANCH: "{{ ATMOSPHERE_ANSIBLE_BRANCH | default('master', true) }}",
         REPO_URI: "{{ ANSIBLE_REPO }}",
         tags: [ 'atmosphere', 'clone-repo'] }
 

--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -14,6 +14,7 @@
         tags: ['dependencies', 'database'] }
 
     - { role: setup-ssl,
+        CREATE_SSL_FILES: "{{ CREATE_SSL | default(True) }}",
         when: clean_target,
         tags: ['dependencies', 'ssl'] }
 

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -36,10 +36,15 @@
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE }}",
         tags: ['atmosphere'] }
 
-    - { role: app-install-instance-deploy-automation,
+    - { role: app-setup-ssh-keys,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
+        CREATE_SSH: "{{ CREATE_SSH_KEYS | default(true) }}",
         SSH_PRIV_KEY: "{{ ID_RSA }}",
         SSH_PUB_KEY: "{{ ID_RSA_PUB }}",
+        tags: ['ansible-deploy'] }
+
+    - { role: app-install-instance-deploy-automation,
+        APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
         INSTANCE_DEPLOY_AUTOMATION_DIR: "{{ ANSIBLE_DEPLOY_LOCATION }}",
         INSTANCE_DEPLOY_AUTOMATION_HOSTS_FILE: "{{ ANSIBLE_HOSTS_FILE }}",
         INSTANCE_DEPLOY_AUTOMATION_GROUP_VARS_FOLDER: "{{ ANSIBLE_GROUP_VARS_FOLDER }}",

--- a/roles/app-install-instance-deploy-automation/tasks/main.yml
+++ b/roles/app-install-instance-deploy-automation/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
 # tasks file for app-install-instance-deploy-automation
 
-- name: insert ansible role path into config file
-  lineinfile: >
-    dest={{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/ansible.cfg
-    regexp="roles_path ="
-    line="roles_path = {{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/roles"
+- name: run configuration for atmosphere-ansible
+  shell: "{{ VIRTUAL_ENV_ATMOSPHERE }}/bin/python {{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/configure"
+  failed_when: False
+  register: output
+
+- debug: var=output.stdout_lines
+  when: "{{ CLANK_VERBOSE | default(False) }}"
 
 - name: move over completed hosts file
   copy: >

--- a/roles/app-install-instance-deploy-automation/tasks/main.yml
+++ b/roles/app-install-instance-deploy-automation/tasks/main.yml
@@ -7,15 +7,6 @@
     regexp="roles_path ="
     line="roles_path = {{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible/roles"
 
-- name: make ssh file directory
-  file: path={{ APP_BASE_DIR }}/extras/ssh/ state=directory
-
-- name: move over id_rsa private key
-  copy: src={{ SSH_PRIV_KEY }} dest={{ APP_BASE_DIR }}/extras/ssh/
-
-- name: move over id_rsa public key
-  copy: src={{ SSH_PUB_KEY }} dest={{ APP_BASE_DIR }}/extras/ssh/
-
 - name: move over completed hosts file
   copy: >
     src={{ INSTANCE_DEPLOY_AUTOMATION_HOSTS_FILE }}
@@ -25,8 +16,3 @@
   copy: >
     src={{ INSTANCE_DEPLOY_AUTOMATION_GROUP_VARS_FOLDER }}
     dest={{ INSTANCE_DEPLOY_AUTOMATION_DIR }}/ansible
-
-
-- name: template over root user ssh config
-  template: src=ssh_config.j2 dest=/root/.ssh/config backup=yes
-

--- a/roles/app-install-instance-deploy-automation/templates/ssh_config.j2
+++ b/roles/app-install-instance-deploy-automation/templates/ssh_config.j2
@@ -1,7 +1,0 @@
-# {{ ansible_managed }}
-
-IdentityFile /root/.ssh/id_rsa
-IdentityFile {{ APP_BASE_DIR }}/extras/ssh/{{ ID_RSA | basename }}
-
-Host *
-    StrictHostKeyChecking no

--- a/roles/app-setup-ssh-keys/tasks/main.yml
+++ b/roles/app-setup-ssh-keys/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# tasks file for setup-ssh-keys
+
+- name: make ssh file directory
+  file: path={{ APP_BASE_DIR }}/extras/ssh/ state=directory
+
+########################################
+# Tasks related to ssh keys being given
+########################################
+- name: move over id_rsa private key
+  copy: src={{ SSH_PRIV_KEY }} dest={{ APP_BASE_DIR }}/extras/ssh/
+  when: not CREATE_SSH
+
+- name: move over id_rsa public key
+  copy: src={{ SSH_PUB_KEY }} dest={{ APP_BASE_DIR }}/extras/ssh/
+  when: not CREATE_SSH
+
+###########################################
+# Tasks related to ssh keys not being given
+###########################################
+- name: Create a 2048-bit SSH key for user root in {{ APP_BASE_DIR }}/extras/ssh/
+  user: name=root generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file={{ APP_BASE_DIR }}/extras/ssh/id_rsa
+  when: CREATE_SSH
+
+- name: template over root user ssh config
+  template: src=ssh_config.j2 dest=/root/.ssh/config backup=yes

--- a/roles/app-setup-ssh-keys/tasks/main.yml
+++ b/roles/app-setup-ssh-keys/tasks/main.yml
@@ -19,7 +19,7 @@
 # Tasks related to ssh keys not being given
 ###########################################
 - name: Create a 2048-bit SSH key for user root in {{ APP_BASE_DIR }}/extras/ssh/
-  user: name=root generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file={{ APP_BASE_DIR }}/extras/ssh/id_rsa
+  user: name=root generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file={{ APP_BASE_DIR }}/extras/ssh/{{ CREATED_SSH_KEY_NAME }} # default is id_rsa
   when: CREATE_SSH
 
 - name: template over root user ssh config

--- a/roles/app-setup-ssh-keys/templates/ssh_config.j2
+++ b/roles/app-setup-ssh-keys/templates/ssh_config.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+
+IdentityFile /root/.ssh/id_rsa
+{% if SSH_PUB_KEY %}
+IdentityFile {{ APP_BASE_DIR }}/extras/ssh/{{ SSH_PUB_KEY | basename }}
+{% else %}
+IdentityFile {{ APP_BASE_DIR }}/extras/ssh/id_rsa
+{% endif %}
+
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null

--- a/roles/app-setup-ssh-keys/vars/main.yml
+++ b/roles/app-setup-ssh-keys/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# vars file for setup-ssh-keys
+
+# Default behavior is to create ssh keys
+CREATE_SSH: true
+
+SSH_PRIV_KEY:
+SSH_PUB_KEY:

--- a/roles/app-setup-ssh-keys/vars/main.yml
+++ b/roles/app-setup-ssh-keys/vars/main.yml
@@ -4,5 +4,7 @@
 # Default behavior is to create ssh keys
 CREATE_SSH: true
 
+CREATED_SSH_KEY_NAME: id_rsa   # you can change this to another name e.g. atmosphere_id_rsa
+
 SSH_PRIV_KEY:
 SSH_PUB_KEY:

--- a/roles/setup-ssl/tasks/main.yml
+++ b/roles/setup-ssl/tasks/main.yml
@@ -8,20 +8,23 @@
     - "default.yml"
   tags: vars
 
+- name: debug create ssl
+  debug: var={{ CREATE_SSL_FILES }}
+
 ########################################
 # Tasks related to ssl certs being given
 ########################################
 - name: copy over ssl certificate
   copy: src={{ SSL_CERTIFICATE }} dest={{ SSL_LOCATION }}/certs/
-  when: not CREATE_SSL
+  when: not CREATE_SSL_FILES
 
 - name: copy over bundle cert
   copy: src={{ BUNDLE_CERT }} dest={{ SSL_LOCATION }}/certs/
-  when: not CREATE_SSL
+  when: not CREATE_SSL_FILES
 
 - name: copy over private ssl key
   copy: src={{ SSL_KEY }} dest={{ SSL_LOCATION }}/private/
-  when: not CREATE_SSL
+  when: not CREATE_SSL_FILES
 
 ########################################
 # Tasks related to ssl certs not given
@@ -39,8 +42,8 @@
   args:
     creates: "{{ SSL_CERTIFICATE }}/certs/{{ item.name }}.crt"
   with_items: "{{ OPENSSL_SELF_SIGNED }}"
-  when: CREATE_SSL
+  when: CREATE_SSL_FILES
 
 - name: Copy over empty bundle file
   file: path={{ SSL_LOCATION }}/certs/empty_bundle.crt state=touch
-  when: CREATE_SSL
+  when: CREATE_SSL_FILES

--- a/roles/setup-ssl/vars/CentOS.yml
+++ b/roles/setup-ssl/vars/CentOS.yml
@@ -1,9 +1,4 @@
+---
+# centos var file for setup-ssl
+
 SSL_LOCATION: /etc/pki/tls
-
-SSL_CERTIFICATE:
-BUNDLE_CERT:
-SSL_KEY:
-
-CREATE_SSL: false
-OPENSSL_SELF_SIGNED:
-  - { name: 'self-signed', country: 'US', state: 'Arizona', city: 'Tucson', organization: 'Foo Bar', unit: '', email: 'foo@bar.com', days: 3650 }

--- a/roles/setup-ssl/vars/Ubuntu.yml
+++ b/roles/setup-ssl/vars/Ubuntu.yml
@@ -1,10 +1,4 @@
+---
+# ubuntu vars file for setup-ssl
+
 SSL_LOCATION: /etc/ssl
-
-SSL_CERTIFICATE:
-BUNDLE_CERT:
-SSL_KEY:
-
-
-CREATE_SSL: false
-OPENSSL_SELF_SIGNED:
-  - { name: 'self-signed', country: 'US', state: 'Arizona', city: 'Tucson', organization: 'Foo Bar', unit: '', email: 'foo@bar.com', days: 3650 }

--- a/roles/setup-ssl/vars/default.yml
+++ b/roles/setup-ssl/vars/default.yml
@@ -1,9 +1,4 @@
+---
+# defaults vars file for setup-ssl 
+
 SSL_LOCATION: /etc/ssl
-
-SSL_CERTIFICATE:
-BUNDLE_CERT:
-SSL_KEY:
-
-CREATE_SSL: false
-OPENSSL_SELF_SIGNED:
-  - { name: 'self-signed', country: 'US', state: 'Arizona', city: 'Tucson', organization: 'Foo Bar', unit: '', email: 'foo@bar.com', days: 3650 }

--- a/roles/setup-ssl/vars/main.yml
+++ b/roles/setup-ssl/vars/main.yml
@@ -1,0 +1,8 @@
+CREATE_SSL_FILES: True
+
+SSL_CERTIFICATE:
+BUNDLE_CERT:
+SSL_KEY:
+
+OPENSSL_SELF_SIGNED:
+  - { name: 'self-signed', country: 'US', state: 'Arizona', city: 'Tucson', organization: 'My Org', unit: '', email: 'foo@bar.com', days: 3650 }


### PR DESCRIPTION
A bit of a large commit.

I wanted to make ssl cert and ssh key creation the default. This will help simplify the process of a new atmosphere/troposphere install for a user/team who just wants to deploy this with minimal effort as possible. I will update our versioned variable.yml files to account for this change assuming the PR has been accepted. 

I created a small ssh key role to help keep things organized and slimmed down the vars files in the `setup-ssl` roles.

Finally, I added in the clone atmosphere-ansible task/role as it was missing from the large rewrite. It uses the general clone-repo that @lenards wrote, rather than adding it as a task elsewhere. 

What I want to have a discussion on is whether we should have atmosphere perform a configure run as Steve wrote in his PR, or should we have the role path edited via lineinfile that is in `app-install-instance-deploy-automation`?