### PR TITLE
Prevent bulldozing of jenkins builds over deploys

### DIFF
--- a/roles/config-nginx-uwsgi/tasks/main.yml
+++ b/roles/config-nginx-uwsgi/tasks/main.yml
@@ -9,12 +9,16 @@
 
 - name: link {{ UWSGI_APP_NAME | default('') }} uwsgi conf file
   file: src={{ UWSGI_APP_SRC }} dest={{ UWSGI_APP_DEST }} state=link
+  tags:
+    - deploy
 
 - name: make nginx configuration files
   shell: make
   args:
     chdir: "{{ APP_BASE_DIR }}/extras/nginx"
   register: output
+  tags:
+    - deploy
 
 - debug: var=output.stdout_lines
   when: "{{ CLANK_VERBOSE | default(False) }}"

--- a/roles/setup-celery/tasks/main.yml
+++ b/roles/setup-celery/tasks/main.yml
@@ -15,11 +15,15 @@
 
 - name: link celeryd init.d script
   file: src={{ ATMOSPHERE_LOCATION }}/extras/init.d/{{ CELERYD }} dest={{ INIT_LOCATION }}/celeryd state=link 
+  tags:
+    - deploy
 
 - name: link celerybeat init.d script
   file: src={{ ATMOSPHERE_LOCATION }}/extras/init.d/{{ CELERYBEAT }} dest={{ INIT_LOCATION }}/celerybeat state=link 
+  tags:
+    - deploy
 
 - name: link default celeryd.defult.dist to /etc/default
   file: src={{ ATMOSPHERE_LOCATION }}/extras/init.d/celeryd.default dest=/etc/default/celeryd state=link
   tags:
-    - deploy_only
+    - deploy

--- a/roles/setup-celery/tasks/main.yml
+++ b/roles/setup-celery/tasks/main.yml
@@ -21,3 +21,5 @@
 
 - name: link default celeryd.defult.dist to /etc/default
   file: src={{ ATMOSPHERE_LOCATION }}/extras/init.d/celeryd.default dest=/etc/default/celeryd state=link
+  tags:
+    - deploy_only


### PR DESCRIPTION
Added a tag to task that should be ran on deployments only.

To use tag for jenkins builds, be sure to add `--skip-tags deploy` to use this feature.

We are still replacing celeryd on the jenkins install.. - @steve-gregory 
`lrwxrwxrwx 1 root root 94 May  4 20:47 /etc/default/celeryd -> /var/lib/jenkins/jobs/Build_Test_Atmosphere/workspace/atmosphere/extras/init.d/celeryd.default`

`atmosphere.ini -> /var/lib/jenkins/jobs/Build_Test_Atmosphere/workspace/atmosphere/extras/uwsgi/atmo.uwsgi.ini
`