### PR TITLE
Add logrotate role

### DIFF
--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -54,3 +54,7 @@
   roles:
     - { role: setup-celery,
         tags: ['atmosphere', 'celery'] }
+
+    - { role: logrotate-files,
+        LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery",
+        tags: ['atmosphere', 'celery', 'logrotate'] }

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -23,6 +23,7 @@
         REQUIREMENTS_FILE_NAME: 'requirements.txt',
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE }}",
         PIP_EXTRA_ARGS: '--no-cache-dir',
+        INSTALL_JEKINS: "{{ JENKINS | default(false) }}",
         tags: ['atmosphere']}
 
     - { role: app-config-logging,

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -31,6 +31,10 @@
         LOG_FILES: "{{ ATMO_LOG_FILES }}",
         tags: ['atmosphere', 'logging']}
 
+    - { role: logrotate-files,
+        LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
+        tags: ['atmosphere', 'logrotate'] }
+
     - { role: app-generate-ini-config,
         template_vars: "{{ ATMO }}",
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -23,7 +23,7 @@
         REQUIREMENTS_FILE_NAME: 'requirements.txt',
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE }}",
         PIP_EXTRA_ARGS: '--no-cache-dir',
-        INSTALL_JEKINS: "{{ JENKINS | default(false) }}",
+        INSTALL_JENKINS: "{{ JENKINS | default(false) }}",
         tags: ['atmosphere']}
 
     - { role: app-config-logging,

--- a/roles/app-pip-install-requirements/tasks/main.yml
+++ b/roles/app-pip-install-requirements/tasks/main.yml
@@ -13,7 +13,7 @@
     requirements={{ APP_BASE_DIR }}/dev_requirements.txt
     virtualenv={{ VIRTUAL_ENV }}
     extra_args={{ PIP_EXTRA_ARGS }}
-  when: JENKINS
+  when: INSTALL_JENKINS 
 
 - name: wheel install requirements
   command: "{{ VIRTUAL_ENV_ATMOSPHERE }}/bin/wheel install-scripts {{ item }}"

--- a/roles/app-pip-install-requirements/vars/main.yml
+++ b/roles/app-pip-install-requirements/vars/main.yml
@@ -8,3 +8,5 @@ VIRTUAL_ENV: ""
 REQUIREMENTS_FILE_NAME: 'dev_requirements.txt'
 
 PIP_EXTRA_ARGS: ""
+
+INSTALL_JENKINS: false

--- a/roles/logrotate-files/README.md
+++ b/roles/logrotate-files/README.md
@@ -34,7 +34,8 @@ or
     - hosts: all
       roles:
         - { role: logrotate-files,
-            LOGROTATE_FILES: "['{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere','{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery']", 
+            LOGROTATE_FILES: "['{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere',
+                               '{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery']", 
             tags: ['atmosphere', 'celery'] }
 ```
 

--- a/roles/logrotate-files/README.md
+++ b/roles/logrotate-files/README.md
@@ -1,0 +1,49 @@
+logrotate-files
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+
+Role Variables
+--------------
+
+- `LOGROTATE_FILES` - the logrotate file or list of files that will be linked to the logrotate file 
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+```
+    - hosts: all
+      roles:
+        - { role: logrotate-files,
+            LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
+            tags: ['atmosphere'] }
+```
+
+or
+
+```
+    - hosts: all
+      roles:
+        - { role: logrotate-files,
+            LOGROTATE_FILES: "['{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere','{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery']", 
+            tags: ['atmosphere', 'celery'] }
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/logrotate-files/README.md
+++ b/roles/logrotate-files/README.md
@@ -1,7 +1,7 @@
 logrotate-files
 =========
 
-A brief description of the role goes here.
+Role that will link from the /etc/logrotate.d directory (by default) to the logroate files in question.
 
 Requirements
 ------------

--- a/roles/logrotate-files/defaults/main.yml
+++ b/roles/logrotate-files/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for logrotate-file
+LOGROATE_CONFD_DIR: /etc/logrotate.d

--- a/roles/logrotate-files/tasks/main.yml
+++ b/roles/logrotate-files/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for logrotate
+# requires a file or list of files to link to the logrotate conf.d dir
+
+- name: link {{ LOGROTATE_FILES | default('') }} file to {{ LOGROATE_CONFD_DIR }}
+  file: src={{ item }} dest={{ LOGROATE_CONFD_DIR }}/{{ item | basename }} state=link
+  with_items:
+    - "{{ LOGROTATE_FILES }}"
+  tags:
+    - deploy


### PR DESCRIPTION
I created logrotate role to allow atmosphere and celery logs to be rotated. The role is generic and can be used by passing in a single file or a list or files to be linked (at the recommendation of Andy Edmonds).

This commit is to address github [issue](https://github.com/iPlantCollaborativeOpenSource/clank/issues/46).

Documentation has been prepared and the role has been tested. 
