### PR TITLE
Handle `nodejs` repository update

### DIFF
--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -27,8 +27,13 @@
 
 # Add apt repositories
 
-- name: add node repository
-  apt_repository: repo='ppa:chris-lea/node.js'
+- name: Add NodeSource repository key
+  apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
+  when: ansible_distribution  == "Ubuntu"
+  tags: apt-install
+
+- name: Add NodeSource repository
+  apt_repository: repo="deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main" state=present
   when: ansible_distribution  == "Ubuntu"
   tags: apt-install
 

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -19,6 +19,12 @@
   with_items: "{{ INITIAL_PACKAGES.packages }}"
   tags: install, apt-install
 
+# Remove deprecated apt repositories
+
+- name: Remove chris-lea nodejs repository
+  apt_repository: repo='ppa:chris-lea/node.js' state=absent
+  when: ansible_distribution  == "Ubuntu"
+
 # Add apt repositories
 
 - name: add node repository


### PR DESCRIPTION
Currently, Clank adds `'ppa:chris-lea/node.js'` and then installs the `nodejs` package from there. This repository is frozen as 0.10.37 (prior to the iojs + nodejs projects {re}merging).

Chris Lea's repository is the basis for [NodeSource](https://nodesource.com/) distribution. So, the current approach for installing from NodeSource is something like: 

```bash
curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
sudo apt-get install -y nodejs
```
source: [nodejs.org/](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)

What this pull request does is: 
- remove `chris-lea/node.js` ppa if present
- add the NodeSource gpg key
- add the NodeSource repository
- install nodejs (4.x) from NodeSource\*\*

✅ Verified within vagrant environment via magnetosphere

\*\* Note: the `nodejs` is part of `DEV_PACKAGES.packages` items and is in task `"install dev packages packages"`

Background: updating to PostCSS for the style bundling created the _need_ to upgrade because the `postcss-loader` Webpack plugins require a _newer_ version of `node`/`npm` then present on servers.