### PR TITLE
Add Nginx team ppa repo for stable, current version

### DIFF
--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -27,8 +27,13 @@
 
 # Add apt repositories
 
-- name: add node repository
-  apt_repository: repo='ppa:chris-lea/node.js'
+- name: Add NodeSource repository key
+  apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
+  when: ansible_distribution  == "Ubuntu"
+  tags: apt-install
+
+- name: Add NodeSource repository
+  apt_repository: repo="deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main" state=present
   when: ansible_distribution  == "Ubuntu"
   tags: apt-install
 

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -19,6 +19,12 @@
   with_items: "{{ INITIAL_PACKAGES.packages }}"
   tags: install, apt-install
 
+# Remove deprecated apt repositories
+
+- name: Remove chris-lea nodejs repository
+  apt_repository: repo='ppa:chris-lea/node.js' state=absent
+  when: ansible_distribution  == "Ubuntu"
+
 # Add apt repositories
 
 - name: add node repository

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -27,6 +27,10 @@
 
 # Add apt repositories
 
+- name: Add Nginx Stable repository
+  apt_repository: repo='ppa:nginx/stable' state=present
+  when: ansible_distribution == "Ubuntu"
+
 - name: Add NodeSource repository key
   apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
   when: ansible_distribution  == "Ubuntu"

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Remove chris-lea nodejs repository
   apt_repository: repo='ppa:chris-lea/node.js' state=absent
-  when: ansible_distribution  == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
 
 # Add apt repositories
 
@@ -33,22 +33,22 @@
 
 - name: Add NodeSource repository key
   apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
-  when: ansible_distribution  == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags: apt-install
 
 - name: Add NodeSource repository
   apt_repository: repo="deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main" state=present
-  when: ansible_distribution  == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags: apt-install
 
 - name: add redis repository
   apt_repository: repo='ppa:chris-lea/redis-server'
-  when: ansible_distribution  == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags: apt-install
 
 - name: update cache as a separate step
   apt: update_cache=yes
-  when: ansible_distribution  == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags: apt-install
 
 - name: install dev packages packages

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -44,7 +44,7 @@ NGINX_PACKAGES:
   packages:
     - uwsgi
     - uwsgi-plugin-python
-    - nginx
+    - nginx-full
   state: latest
 
 APACHE: apache2


### PR DESCRIPTION
This gives Ubuntu Trusty (14.04) access to a most recent nginx version.

We are also opting for the `nginx-full` package here. A call to `nginx -V` will give you a complete listing of all modules present following the install. 

The LTS has nginx 1.4.6 as the stock, available package. Including the stable ppa from the Nginx team will give us access to nginx 1.10.*

This means the HTTP/2 module can be enable to increase the delivery throughput of assets (images, style, typography, javascript).

See [ATMO-1372](https://pods.iplantcollaborative.org/jira/browse/ATMO-1372)
Relates to [ATMO-1189](https://pods.iplantcollaborative.org/jira/browse/ATMO-1189)