### PR TITLE
Remove pycs

### DIFF
--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -26,6 +26,11 @@
         INSTALL_JENKINS: "{{ JENKINS | default(false) }}",
         tags: ['atmosphere']}
 
+    - { role: delete-files,
+        LOCATION: "{{ ATMOSPHERE_LOCATION }}",
+        GLOB: "*.pyc",
+        tags: ['atmosphere'] }
+
     - { role: app-config-logging,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
         LOG_FILES: "{{ ATMO_LOG_FILES }}",

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -18,6 +18,15 @@
         DATABASE_FILE_TO_BE_LOADED: "{{ ATMO_DATA.SQL_DUMP_FILE }}",
         tags: ['atmosphere', 'data-load'] }
 
+    - { role: logrotate-files,
+        LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
+        tags: ['atmosphere', 'logrotate'] }
+
+    - { role: delete-files,
+        LOCATION: "{{ ATMOSPHERE_LOCATION }}",
+        GLOB: "*.pyc",
+        tags: ['atmosphere'] }
+
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
         REQUIREMENTS_FILE_NAME: 'requirements.txt',
@@ -26,19 +35,10 @@
         INSTALL_JENKINS: "{{ JENKINS | default(false) }}",
         tags: ['atmosphere']}
 
-    - { role: delete-files,
-        LOCATION: "{{ ATMOSPHERE_LOCATION }}",
-        GLOB: "*.pyc",
-        tags: ['atmosphere'] }
-
     - { role: app-config-logging,
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
         LOG_FILES: "{{ ATMO_LOG_FILES }}",
         tags: ['atmosphere', 'logging']}
-
-    - { role: logrotate-files,
-        LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
-        tags: ['atmosphere', 'logrotate'] }
 
     - { role: app-generate-ini-config,
         template_vars: "{{ ATMO }}",

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -15,14 +15,19 @@
         DATABASE_FILE_TO_BE_LOADED: "{{ TROPO_DATA.SQL_DUMP_FILE }}",
         tags: ['troposphere', 'data-load'] }
 
+    - { role: logrotate-files,
+        LOGROTATE_FILES: "{{ TROPOSPHERE_LOCATION }}/extras/logrotate.troposphere",
+        tags: ['troposphere', 'logrotate'] }
+
+    - { role: delete-files,
+        LOCATION: "{{ TROPOSPHERE_LOCATION }}",
+        GLOB: "*.pyc",
+        tags: ['troposphere'] }
+
     - { role: app-pip-install-requirements,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION }}",
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE }}",
         tags: ['troposphere']}
-
-    - { role: logrotate-files,
-        LOGROTATE_FILES: "{{ TROPOSPHERE_LOCATION }}/extras/logrotate.troposphere",
-        tags: ['troposphere', 'logrotate'] }
 
     - { role: app-config-logging,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION }}",

--- a/roles/delete-files/README.md
+++ b/roles/delete-files/README.md
@@ -29,6 +29,17 @@ Including an example of how to use your role (for instance, with variables passe
         GLOB: "*.pyc",
         tags: ['atmosphere'] }
 ```
+or
+
+```
+- hosts: all
+  roles:
+    - { role: delete-files,
+        LOCATION: "{{ ATMOSPHERE_LOCATION",
+        GLOB: "*.bak*",
+        tags: ['atmosphere'] }
+```
+
 
 License
 -------

--- a/roles/delete-files/README.md
+++ b/roles/delete-files/README.md
@@ -1,0 +1,50 @@
+logrotate-files
+=========
+
+Role that will link from the /etc/logrotate.d directory (by default) to the logroate files in question.
+
+Requirements
+------------
+
+
+Role Variables
+--------------
+
+- `LOGROTATE_FILES` - the logrotate file or list of files that will be linked to the logrotate file 
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+```
+    - hosts: all
+      roles:
+        - { role: logrotate-files,
+            LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
+            tags: ['atmosphere'] }
+```
+
+or
+
+```
+    - hosts: all
+      roles:
+        - { role: logrotate-files,
+            LOGROTATE_FILES: "['{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere',
+                               '{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery']", 
+            tags: ['atmosphere', 'celery'] }
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/delete-files/README.md
+++ b/roles/delete-files/README.md
@@ -22,7 +22,8 @@ Example Playbook
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
 ```
-      roles:
+- hosts: all
+  roles:
     - { role: delete-files,
         LOCATION: "/opt/dev/atmosphere",
         GLOB: "*.pyc",

--- a/roles/delete-files/README.md
+++ b/roles/delete-files/README.md
@@ -1,7 +1,7 @@
-logrotate-files
+delete-files
 =========
 
-Role that will link from the /etc/logrotate.d directory (by default) to the logroate files in question.
+Role to search and recursively delete files matching a location and glob 
 
 Requirements
 ------------
@@ -10,7 +10,8 @@ Requirements
 Role Variables
 --------------
 
-- `LOGROTATE_FILES` - the logrotate file or list of files that will be linked to the logrotate file 
+- `LOCATION` - the location where you want to recursively search for a file matching the glob 
+- `GLOB` - the glob you wish to search for file based off of
 
 Dependencies
 ------------
@@ -21,22 +22,11 @@ Example Playbook
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
 ```
-    - hosts: all
       roles:
-        - { role: logrotate-files,
-            LOGROTATE_FILES: "{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere",
-            tags: ['atmosphere'] }
-```
-
-or
-
-```
-    - hosts: all
-      roles:
-        - { role: logrotate-files,
-            LOGROTATE_FILES: "['{{ ATMOSPHERE_LOCATION }}/extras/logrotate.atmosphere',
-                               '{{ ATMOSPHERE_LOCATION }}/extras/logrotate.celery']", 
-            tags: ['atmosphere', 'celery'] }
+    - { role: delete-files,
+        LOCATION: "/opt/dev/atmosphere",
+        GLOB: "*.pyc",
+        tags: ['atmosphere'] }
 ```
 
 License

--- a/roles/delete-files/defaults/main.yml
+++ b/roles/delete-files/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for delete-files role

--- a/roles/delete-files/tasks/main.yml
+++ b/roles/delete-files/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for delete file
+# requires a location and a glob
+
+- name: list all files matching at a location with a glob
+  shell: find {{ LOCATION }} -name "{{ GLOB }}" -exec /bin/rm {} \;
+  register: output
+
+- name: debug list
+  debug: var=output.stdout_lines
+  when: "{{ CLANK_VERBOSE | default(False) }}"


### PR DESCRIPTION
This is to address issue [55](https://github.com/iPlantCollaborativeOpenSource/clank/issues/55). This role is generic and can accept a location to recursively search down and matching a file glob that is provided. Then nuke it. It as has been added to the setup_atmosphere.yml playbook so we should be able to remove that issue going forward.