### PR TITLE
Template ssh config and set var to false if user doesn't want it to be generated

### DIFF
--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -66,7 +66,10 @@ TROPO_DATA:
     SQL_DUMP_FILE:                          # an absolute path to sql script that you want loaded /root/some_sql.sql
 
 # SSL RELATED VARS
+GENERATE_SSH_CONFIG: true                  # Set this to false if you wish to keep your .ssh/config
+
 CREATE_SSL: true                           # Set this to false if you wish to pass in your own certs
+
 # If the above variable is set to true, don't edit next three vars below
 SSL_CERTIFICATE:    #Absolute Path Recommended
 BUNDLE_CERT:        #Absolute Path Recommended

--- a/roles/app-setup-ssh-keys/tasks/main.yml
+++ b/roles/app-setup-ssh-keys/tasks/main.yml
@@ -22,17 +22,13 @@
   user: name=root generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file={{ APP_BASE_DIR }}/extras/ssh/{{ CREATED_SSH_KEY_NAME }} # default is id_rsa
   when: CREATE_SSH
 
-- name: touch .ssh/config
-  file: path=/root/.ssh/config state=touch mode=0700
+- name: set ssh priv key var if they do not supply one
+  set_fact: SSH_PRIV_KEY={{ CREATED_SSH_KEY_NAME }}
+  when: CREATE_SSH
 
-- name: insert Host * directive at bottom of .ssh config file 
-  blockinfile: 
-    dest: /root/.ssh/config 
-    insertafter: EOF
-    content: |
-      Host *
-          IdentityFile {{ APP_BASE_DIR }}/extras/ssh/{{ SSH_PRIV_KEY | basename | default('id_rsa') }}
-          StrictHostKeyChecking no
-          UserKnownHostsFile=/dev/null
-  tags:
-    - deploy
+###########################################
+# Genereate ssh config when var is true
+###########################################
+- name: template over system's ssh config
+  template: src=ssh_config.j2 dest=/root/.ssh/config backup=yes
+  when: GENERATE_SSH_CONFIG

--- a/roles/app-setup-ssh-keys/templates/ssh_config.j2
+++ b/roles/app-setup-ssh-keys/templates/ssh_config.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+Host *
+    IdentityFile {{ APP_BASE_DIR }}/extras/ssh/{{ SSH_PRIV_KEY | basename | default('id_rsa') }}
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null

--- a/roles/app-setup-ssh-keys/vars/main.yml
+++ b/roles/app-setup-ssh-keys/vars/main.yml
@@ -4,6 +4,9 @@
 # Default behavior is to create ssh keys
 CREATE_SSH: true
 
+# Default behavior is to generate ssh config
+GENERATE_SSH_CONFIG: true
+
 CREATED_SSH_KEY_NAME: id_rsa   # you can change this to another name e.g. atmosphere_id_rsa
 
 SSH_PRIV_KEY:


### PR DESCRIPTION
In an effort to remove the bug of blockinfile not properly capturing the Host * directive, I decided to template out the .ssh/config file. This works well, has a comment at the top stating that it is being managed by ansible, and points to the private ssh key that is injected by ansible in the config with proper naming. 

If you do not wish to have to ansible write over the ssh config that may be in place, you can set `GENERATE_SSH_CONFIG` to `false` and it will skip over this task.

This should address issue [56](https://github.com/iPlantCollaborativeOpenSource/clank/issues/56).