### PR TITLE
Condense apt-keys and apt-repos into lists that can easily be added onto

### DIFF
--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -1,4 +1,3 @@
-
 # tasks file for atmosphere-install-dependencies
 
 - name: gather os specific variables
@@ -20,33 +19,20 @@
   with_items: "{{ INITIAL_PACKAGES.packages }}"
   tags: install, apt-install
 
-# Remove deprecated apt repositories
-
-- name: Remove chris-lea nodejs repository
-  apt_repository: repo='ppa:chris-lea/node.js' state=absent
+- name: remove old apt respositories
+  apt_repository: repo={{ item }} state={{ APT_REPOSITORIES_TO_REMOVE.state }}
+  with_items: "{{ APT_REPOSITORIES_TO_REMOVE.packages }}"
   when: ansible_distribution == "Ubuntu"
 
-# Add apt repositories
+- name: add apt keys
+  apt_key: url={{ item }} state={{ APT_KEYS_TO_ADD.state }}
+  with_items: "{{ APT_KEYS_TO_ADD.packages }}"
+  when: ansible_distribution == "Ubuntu" 
 
-- name: Add Nginx Stable repository
-  apt_repository: repo='ppa:nginx/stable' state=present
-  when: ansible_distribution == "Ubuntu"
-  tags: apt-install
-
-- name: Add NodeSource repository key
-  apt_key: url="https://deb.nodesource.com/gpgkey/nodesource.gpg.key" state=present
-  when: ansible_distribution == "Ubuntu"
-  tags: apt-install
-
-- name: Add NodeSource repository
-  apt_repository: repo="deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main" state=present
-  when: ansible_distribution == "Ubuntu"
-  tags: apt-install
-
-- name: add redis repository
-  apt_repository: repo='ppa:chris-lea/redis-server'
-  when: ansible_distribution == "Ubuntu"
-  tags: apt-install
+- name: add apt repositories
+  apt_repository: repo={{ item }} state={{ APT_REPOSITORIES_TO_ADD.state }}
+  with_items: "{{ APT_REPOSITORIES_TO_ADD.packages }}"
+  when: ansible_distribution == "Ubuntu" 
 
 - name: update cache as a separate step
   apt: update_cache=yes

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -15,22 +15,22 @@
 
 - name: install initial packages packages
   action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state={{ INITIAL_PACKAGES.state }} update_cache=yes
+    {{ ansible_pkg_mgr }} name={{ item }} state=latest update_cache=yes
   with_items: "{{ INITIAL_PACKAGES.packages }}"
   tags: install, apt-install
 
 - name: remove old apt respositories
-  apt_repository: repo={{ item }} state={{ APT_REPOSITORIES_TO_REMOVE.state }}
+  apt_repository: repo={{ item }} state=absent
   with_items: "{{ APT_REPOSITORIES_TO_REMOVE.packages }}"
   when: ansible_distribution == "Ubuntu"
 
 - name: add apt keys
-  apt_key: url={{ item }} state={{ APT_KEYS_TO_ADD.state }}
+  apt_key: url={{ item }} state=present
   with_items: "{{ APT_KEYS_TO_ADD.packages }}"
   when: ansible_distribution == "Ubuntu" 
 
 - name: add apt repositories
-  apt_repository: repo={{ item }} state={{ APT_REPOSITORIES_TO_ADD.state }}
+  apt_repository: repo={{ item }} state=present
   with_items: "{{ APT_REPOSITORIES_TO_ADD.packages }}"
   when: ansible_distribution == "Ubuntu" 
 
@@ -41,19 +41,19 @@
 
 - name: install dev packages packages
   action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state={{ DEV_PACKAGES.state }}
+    {{ ansible_pkg_mgr }} name={{ item }} state=latest
   with_items: "{{ DEV_PACKAGES.packages }}"
   tags: install, apt-install
 
 - name: install lib packages packages
   action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state={{ LIB_PACKAGES.state }}
+    {{ ansible_pkg_mgr }} name={{ item }} state=latest
   with_items: "{{ LIB_PACKAGES.packages }}"
   tags: install, apt-install
 
 - name: install nginx packages packages
   action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state={{ NGINX_PACKAGES.state }}
+    {{ ansible_pkg_mgr }} name={{ item }} state=latest
   with_items: "{{ NGINX_PACKAGES.packages }}"
   tags: install, apt-install
 

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -1,3 +1,20 @@
+APT_REPOSITORIES_TO_REMOVE:
+  packages:
+    - ppa:chris-lea/node.js
+  state: absent
+
+APT_KEYS_TO_ADD:
+  packages:
+    - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+  state: present
+
+APT_REPOSITORIES_TO_ADD:
+  packages:
+    - ppa:nginx/stable
+    - deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main
+    - ppa:chris-lea/redis-server
+  state: present
+
 INITIAL_PACKAGES:
   packages:
     - software-properties-common
@@ -48,3 +65,5 @@ NGINX_PACKAGES:
   state: latest
 
 APACHE: apache2
+
+

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -65,5 +65,3 @@ NGINX_PACKAGES:
   state: latest
 
 APACHE: apache2
-
-

--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -1,25 +1,21 @@
 APT_REPOSITORIES_TO_REMOVE:
   packages:
     - ppa:chris-lea/node.js
-  state: absent
 
 APT_KEYS_TO_ADD:
   packages:
     - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-  state: present
 
 APT_REPOSITORIES_TO_ADD:
   packages:
     - ppa:nginx/stable
     - deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main
     - ppa:chris-lea/redis-server
-  state: present
 
 INITIAL_PACKAGES:
   packages:
     - software-properties-common
     - python-software-properties
-  state: latest
 
 DEV_PACKAGES:
   packages:
@@ -47,7 +43,6 @@ DEV_PACKAGES:
     - python-pip
     - python-setuptools
     - ufw
-  state: latest
 
 LIB_PACKAGES:
   packages:
@@ -55,13 +50,11 @@ LIB_PACKAGES:
     - libxslt1-dev
     - python-tk
     - zlib1g-dev
-  state: latest
 
 NGINX_PACKAGES:
   packages:
     - uwsgi
     - uwsgi-plugin-python
     - nginx-full
-  state: latest
 
 APACHE: apache2


### PR DESCRIPTION
This PR is to address the issue brought up in [53](https://github.com/iPlantCollaborativeOpenSource/clank/issues/53) and what @nfaction was trying to explain in issue [51](https://github.com/iPlantCollaborativeOpenSource/clank/pull/51). The code removes multiple unnecessary tasks and creates three lists that can easily be appended to if we wish to add any apt repos/keys going forward. The code has been tested.