### PR TITLE
Remove node_modules when npm install fails and launches second attempt

### DIFF
--- a/roles/build-install-troposphere-ui-assets/tasks/main.yml
+++ b/roles/build-install-troposphere-ui-assets/tasks/main.yml
@@ -5,13 +5,32 @@
   file: path={{ NPM_APP_DIR }}/node_modules state=absent
   when: NPM_CLEAN_BUILD
 
+- name: disable npm progress bar for speed boost
+  shell: npm set progress=false
+  register: result
+  
+- debug: var=result.stdout_lines
+  when: "{{ CLANK_VERBOSE | default(False) }}"
+
 - name: run npm install
+  action: shell npm install
+  args:
+    chdir: "{{ NPM_APP_DIR }}"
+  register: first_run
+  failed_when: false
+
+- name: remove node modules after failed first attempt
+  file: path={{ NPM_APP_DIR }}/node_modules state=absent
+  when: first_run.rc != 0
+
+- name: run npm install after failed first attempt
   action: shell npm install
   args:
     chdir: "{{ NPM_APP_DIR }}"
   register: result
   until: result.rc == 0
   retries: 2
+  when: first_run.rc != 0 
 
 - debug: var=result.stdout_lines
   when: "{{ CLANK_VERBOSE | default(False) }}"


### PR DESCRIPTION
This PR is to address issue [54](https://github.com/iPlantCollaborativeOpenSource/clank/issues/54). 

We first run `npm set progress=false` to help increase npm install build times. You can see this [article](https://davidwalsh.name/faster-npm) for more info about this. 

Next we run an initial `npm install` and record its results. If it fails, we delete `node_modules` and re run the install again (try twice for any funky npm voodoo). 

There is a slight speed increase and is noted below:
```
# When npm set progress=true

/root/clank/clank_env/bin/ansible-playbook /root/clank/playbooks/deploy_stack.yml --flush-cache -c local -i "/root/clank/local_inventory" --skip-tags="dependencies,atmosphere" -e "@/root/clank/variables.yml@atmo"

real    2m56.866s
user    2m21.271s
sys     0m29.787s

# When npm set progress=false

/root/clank/clank_env/bin/ansible-playbook /root/clank/playbooks/deploy_stack.yml --flush-cache -c local -i "/root/clank/local_inventory" --skip-tags="dependencies,atmosphere" -e "@/root/clank/variables.yml@atmo"

real    2m40.108s
user    2m6.941s
sys     0m26.927s
```