### PR TITLE
Add callback plugin for human readable error output

### DIFF
--- a/ansible.cfg.j2
+++ b/ansible.cfg.j2
@@ -117,7 +117,7 @@ ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid}
 
 # set plugin path directories here, separate with colons
 action_plugins     = /usr/share/ansible_plugins/action_plugins
-callback_plugins   = /usr/share/ansible_plugins/callback_plugins
+callback_plugins   = ./callback_plugins:/usr/share/ansible_plugins/callback_plugins
 connection_plugins = /usr/share/ansible_plugins/connection_plugins
 lookup_plugins     = /usr/share/ansible_plugins/lookup_plugins
 vars_plugins       = /usr/share/ansible_plugins/vars_plugins

--- a/callback_plugins/human_log.py
+++ b/callback_plugins/human_log.py
@@ -1,0 +1,147 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Inspired from: https://gist.github.com/cliffano/9868180
+# Improved and made compatible with Ansible v2
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.callback import CallbackBase
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+# Fields to reformat output for
+FIELDS = ['cmd', 'command', 'start', 'end', 'delta', 'msg', 'stdout',
+          'stderr', 'results']
+
+
+class CallbackModule(CallbackBase):
+    def human_log(self, data):
+        if type(data) == dict:
+            for field in FIELDS:
+                if field in data.keys() and data[field]:
+                    output = self._format_output(data[field])
+                    print("\n{0}: {1}".format(field, output.replace("\\n","\n")))
+
+    def _format_output(self, output):
+        # Strip unicode
+        if type(output) == unicode:
+            output = output.encode('ascii', 'replace')
+
+        # If output is a dict
+        if type(output) == dict:
+            return json.dumps(output, indent=2)
+
+        # If output is a list of dicts
+        if type(output) == list and type(output[0]) == dict:
+            # This gets a little complicated because it potentially means
+            # nested results, usually because of with_items.
+            real_output = list()
+            for index, item in enumerate(output):
+                copy = item
+                if type(item) == dict:
+                    for field in FIELDS:
+                        if field in item.keys():
+                            copy[field] = self._format_output(item[field])
+                real_output.append(copy)
+            return json.dumps(output, indent=2)
+
+        # If output is a list of strings
+        if type(output) == list and type(output[0]) != dict:
+            # Strip newline characters
+            real_output = list()
+            for item in output:
+                if "\n" in item:
+                    for string in item.split("\n"):
+                        real_output.append(string)
+                else:
+                    real_output.append(item)
+
+            # Reformat lists with line breaks only if the total length is
+            # >75 chars
+            if len("".join(real_output)) > 75:
+                return "\n" + "\n".join(real_output)
+            else:
+                return " ".join(real_output)
+
+        # Otherwise it's a string, just return it
+        return output
+
+    def on_any(self, *args, **kwargs):
+        pass
+
+    def runner_on_failed(self, host, res, ignore_errors=False):
+        self.human_log(res)
+
+    def runner_on_ok(self, host, res):
+        self.human_log(res)
+
+
+    def runner_on_error(self, host, msg):
+        pass
+
+    def runner_on_skipped(self, host, item=None):
+        pass
+
+    def runner_on_unreachable(self, host, res):
+        self.human_log(res)
+
+    def runner_on_no_hosts(self):
+        pass
+
+    def runner_on_async_poll(self, host, res, jid, clock):
+        self.human_log(res)
+
+    def runner_on_async_ok(self, host, res, jid):
+        self.human_log(res)
+
+    def runner_on_async_failed(self, host, res, jid):
+        self.human_log(res)
+
+    def playbook_on_start(self):
+        pass
+
+    def playbook_on_notify(self, host, handler):
+        pass
+
+    def playbook_on_no_hosts_matched(self):
+        pass
+
+    def playbook_on_no_hosts_remaining(self):
+        pass
+
+    def playbook_on_task_start(self, name, is_conditional):
+        pass
+
+    def playbook_on_vars_prompt(self, varname, private=True, prompt=None,
+                                encrypt=None, confirm=False, salt_size=None,
+                                salt=None, default=None):
+        pass
+
+    def playbook_on_setup(self):
+        pass
+
+    def playbook_on_import_for_host(self, host, imported_file):
+        pass
+
+    def playbook_on_not_import_for_host(self, host, missing_file):
+        pass
+
+    def playbook_on_play_start(self, pattern):
+        pass
+
+    def playbook_on_stats(self, stats):
+        pass


### PR DESCRIPTION
After an embarrassing meeting and having trouble reading output from the configure script, I have added a callback plugin that will make spit the output as intended.

Takes this:

```
 TASK [app-generate-ini-config : run generate script for app] *******************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "/opt/env/troposphere/bin/python /opt/dev/troposphere/configure", "delta": "0:00:00.166891", "end": "2016-06-27 11:59:02.153102", "failed": true, "rc": 1, "start": "2016-06-27 11:59:01.986211", "stderr": "", "stdout": "\u001b[30m\u001b[46m\nProject Path => /opt/dev/troposphere\u001b[0m\n\n\nTesting for preconditions...\n\n\u001b[31mError found in /opt/dev/troposphere/troposphere/settings/local.py.j2\u001b[0m\n\u001b[33mUndeclared variables found in /opt/dev/troposphere/troposphere/settings/local.py.j2: \n\t- AUTH_ENABLE_LDAP\n\t- AUTH_ENABLE_CAS\n\t- AUTH_ENABLE_MOCK\n\t- AUTH_ENABLE_OAUTH\n\t- AUTH_ENABLE_MODEL\n\t- AUTH_USE_OVERRIDE\n\t- AUTH_ENABLE_GLOBUS \n\u001b[0m\n\u001b[33mUnused variables found in section local.py: \n\t- OAUTH_ISSUE_USER\n\u001b[0m\n\u001b[33mUnused variables found in section COMMON: \n\t- DJANGO_SERVER_URL\n\t- LDAP_SERVER\n\t- LDAP_SERVER_DN\n\u001b[0m\n\n\n\u001b[31mConfiguration files were not generated.\n\u001b[0m\n\u001b[30m\u001b[41mFAILED.\u001b[0m ", "stdout_lines": ["\u001b[30m\u001b[46m", "Project Path => /opt/dev/troposphere\u001b[0m", "", "", "Testing for preconditions...", "", "\u001b[31mError found in /opt/dev/troposphere/troposphere/settings/local.py.j2\u001b[0m", "\u001b[33mUndeclared variables found in /opt/dev/troposphere/troposphere/settings/local.py.j2: ", "\t- AUTH_ENABLE_LDAP", "\t- AUTH_ENABLE_CAS", "\t- AUTH_ENABLE_MOCK", "\t- AUTH_ENABLE_OAUTH", "\t- AUTH_ENABLE_MODEL", "\t- AUTH_USE_OVERRIDE", "\t- AUTH_ENABLE_GLOBUS ", "\u001b[0m", "\u001b[33mUnused variables found in section local.py: ", "\t- OAUTH_ISSUE_USER", "\u001b[0m", "\u001b[33mUnused variables found in section COMMON: ", "\t- DJANGO_SERVER_URL", "\t- LDAP_SERVER", "\t- LDAP_SERVER_DN", "\u001b[0m", "", "", "\u001b[31mConfiguration files were not generated.", "\u001b[0m", "\u001b[30m\u001b[41mFAILED.\u001b[0m "], "warnings": []}
```

and converts it to:
```
33mUndeclared variables found in /opt/dev/troposphere/troposphere/settings/local.py.j2: \n\t- AUTH_ENABLE_LDAP\n\t- AUTH_ENABLE_CAS\n\t- AUTH_ENABLE_MOCK\n\t- AUTH_ENABLE_OAUTH\n\t- AUTH_ENABLE_MODEL\n\t- AUTH_USE_OVERRIDE\n\t- AUTH_ENABLE_GLOBUS \n\u001b[0m\n\u001b[33mUnused variables found in section local.py: \n\t- OAUTH_ISSUE_USER\n\u001b[0m\n\u001b[33mUnused variables found in section COMMON: \n\t- DJANGO_SERVER_URL\n\t- LDAP_SERVER\n\t- LDAP_SERVER_DN\n\u001b[0m\n\n\n\u001b[31mConfiguration files were not generated.\n\u001b[0m\n\u001b[30m\u001b[41mFAILED.\u001b[0m ", "stdout_lines": ["\u001b[30m\u001b[46m", "Project Path => /opt/dev/troposphere\u001b[0m", "", "", "Testing for preconditions...", "", "\u001b[31mError found in /opt/dev/troposphere/troposphere/settings/local.py.j2\u001b[0m", "\u001b[33mUndeclared variables found in /opt/dev/troposphere/troposphere/settings/local.py.j2: ", "\t- AUTH_ENABLE_LDAP", "\t- AUTH_ENABLE_CAS", "\t- AUTH_ENABLE_MOCK", "\t- AUTH_ENABLE_OAUTH", "\t- AUTH_ENABLE_MODEL", "\t- AUTH_USE_OVERRIDE", "\t- AUTH_ENABLE_GLOBUS ", "\u001b[0m", "\u001b[33mUnused variables found in section local.py: ", "\t- OAUTH_ISSUE_USER", "\u001b[0m", "\u001b[33mUnused variables found in section COMMON: ", "\t- DJANGO_SERVER_URL", "\t- LDAP_SERVER", "\t- LDAP_SERVER_DN", "\u001b[0m", "", "", "\u001b[31mConfiguration files were not generated.", "\u001b[0m", "\u001b[30m\u001b[41mFAILED.\u001b[0m "], "warnings": []}

cmd: /opt/env/troposphere/bin/python /opt/dev/troposphere/configure

start: 2016-06-27 12:06:58.546635

end: 2016-06-27 12:06:58.695857

delta: 0:00:00.149222

stdout: 
Project Path => /opt/dev/troposphere


Testing for preconditions...

Error found in /opt/dev/troposphere/troposphere/settings/local.py.j2
Undeclared variables found in /opt/dev/troposphere/troposphere/settings/local.py.j2: 
        - AUTH_ENABLE_LDAP
        - AUTH_ENABLE_CAS
        - AUTH_ENABLE_MOCK
        - AUTH_ENABLE_OAUTH
        - AUTH_ENABLE_MODEL
        - AUTH_USE_OVERRIDE
        - AUTH_ENABLE_GLOBUS 

Unused variables found in section local.py: 
        - OAUTH_ISSUE_USER

Unused variables found in section COMMON: 
        - DJANGO_SERVER_URL
        - LDAP_SERVER
        - LDAP_SERVER_DN



Configuration files were not generated.

FAILED. 
```
The plugin also revels what shell and command module commands are being ran as a bonus. 