### PR TITLE
Remove unnecessary install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Fetch packages required to build dependencies.
 ```bash
 apt-get update
 apt-get install -y git python python-pip python-dev libffi-dev libssl-dev
-pip install --upgrade pip virtualenv
 ```
 
 Fetch the repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 colorama
 ansible==2.1.0.0
+
+# This can be removed if and when https://github.com/ansible/ansible/pull/16723 gets resolved
+setuptools>=11.3 


### PR DESCRIPTION
This fix makes a clank install more likely to succeed. You no longer need the latest virtualenv/pip.

The reason we had to update the virtualenv is to install a later version of setuptools which ansible (silently) required. This is a bug in ansible. It is documented in the requirements.txt.