### PR TITLE
Add official PostgreSQL Apt Repository

### DIFF
--- a/roles/install-dependencies/vars/Ubuntu.yml
+++ b/roles/install-dependencies/vars/Ubuntu.yml
@@ -5,11 +5,13 @@ APT_REPOSITORIES_TO_REMOVE:
 APT_KEYS_TO_ADD:
   packages:
     - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    - https://www.postgresql.org/media/keys/ACCC4CF8.asc
 
 APT_REPOSITORIES_TO_ADD:
   packages:
     - ppa:nginx/stable
     - deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main
+    - deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main
     - ppa:chris-lea/redis-server
 
 INITIAL_PACKAGES:


### PR DESCRIPTION
The PostgreSQL project managed an Apt Repository [1], this will include
it and make new versions of the database available to the current
distro version, 14.04.3.

Thank you to Connor Osborn for refactoring this role to use lists.

[1] https://www.postgresql.org/download/linux/ubuntu/