### PR TITLE
Changed `_format_output()` to always return a str

### DIFF
--- a/callback_plugins/human_log.py
+++ b/callback_plugins/human_log.py
@@ -77,8 +77,8 @@ class CallbackModule(CallbackBase):
             else:
                 return " ".join(real_output)
 
-        # Otherwise it's a string, just return it
-        return output
+        # Otherwise it's a string (int, float, bool), just return it
+        return str(output)
 
     def on_any(self, *args, **kwargs):
         pass

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -241,7 +241,7 @@ ATMO:
         USER_EMAIL_LOOKUP_METHOD: ldap_get_email_info
         INSTANCE_HOSTNAMING_DOMAIN: # host domain VMs will have
         INSTANCE_HOSTNAMING_FORMAT: vm%(three)s-%(four)s.%(domain)s
-        DEPLOYMENT_KEYPAIR_NAME = # keypair name inject by atmo-ansible during instance deploy
+        DEPLOYMENT_KEYPAIR_NAME: # keypair name inject by atmo-ansible during instance deploy
         CELERYBEAT_SCHEDULE: {"monitor_instances": {"schedule": 'timedelta(minutes=5)',}}
 
     secrets.py:


### PR DESCRIPTION
In some situations, the logic of `_format_output(output)` will allow a non-string to make it down to Line 81. When? Will, if output is a `bool`, then you encounter the situation described in #90. 

Now, `_format_output` always returns a `str` and there will always be a `.replace` method available - but the formatting will not affect the overall result (just *no* _more_ `[WARNING]`).