### PR TITLE
Added playbook to upgrade to new Postgres

### DIFF
--- a/playbooks/utils/upgrade_postgres.yml
+++ b/playbooks/utils/upgrade_postgres.yml
@@ -1,0 +1,110 @@
+---
+- name: Checking for necessary --extra_vars
+  hosts: all
+  vars:
+    example:
+      - "-e \"{pg_version: '9.5',  pg_version_old: '9.3'}\""
+      - "-e \"{pg_version: '9.5',  pg_version_old: '9.3'}\""
+      - "-e \"{database_names: ['atmosphere', 'troposphere']}\""
+
+  tasks:
+
+    - fail: msg="\nMust set pg_version.\nPass a value in via `-e` as JSON -\n\t {{example[0]}}"
+      when: "{{ pg_version is undefined }}"
+
+    - fail: msg="\nMust set pg_version_old.\nPass a value in via `-e` as JSON -\n\t {{example[1]}}"
+      when: "{{ pg_version_old is undefined }}"
+
+    - debug: msg="Consider passing in `database_names`.\nPass a value in via `-e` as JSON -\n\t {{example[2]}}"
+      when: "{{ database_names is undefined or database_names == []}}"
+
+
+- name: Ensure PostgreSQL service available
+  hosts: all
+
+  tasks:
+    - service: name=postgresql state=started
+
+- name: Backup all Postgres tables
+  hosts: all
+
+  roles:
+    - { role: app-backup-postgres,
+        database_names: ['atmo_prod', 'troposphere'],
+        tags: ['data-backup', 'backup', 'upgrade'] }
+
+
+- name: Stop PostgreSQL service
+  hosts: all
+
+  tasks:
+    - service: name=postgresql state=stopped
+
+- name: Upgrade PostgreSQL
+  hosts: all
+
+  tasks:
+    - name: Install new postgresql packages
+      action: >
+        {{ ansible_pkg_mgr }} name={{ item }} state=latest update_cache=yes
+      with_items:
+        - postgresql-{{ pg_version }}
+        - postgresql-contrib-{{ pg_version }}
+        - postgresql-server-dev-{{ pg_version }}
+      tags: ['install', 'upgrade']
+
+    - name: List current postgresql clusters
+      shell: pg_lsclusters
+      register: list_clusters
+
+    - debug: msg="{{ list_clusters.stdout_lines }}"
+
+    - name: Drop default install postgresql cluster
+      command: >
+        pg_dropcluster --stop {{ pg_version }} main
+
+    - name: Upgrade existing postgresql cluster
+      command: >
+        pg_upgradecluster {{ pg_version_old }} main
+
+- name: Start upgraded PostgreSQL service
+  hosts: all
+
+  tasks:
+    - service: name=postgresql state=started args=9.5
+
+    - name: List current postgresql clusters
+      shell: pg_lsclusters
+      register: list_clusters
+
+    - debug: msg="{{ list_clusters.stdout_lines }}"
+
+- name: Clean up
+  hosts: all
+
+  tasks:
+    - name: Drop default install postgresql cluster
+      command: >
+        pg_dropcluster --stop {{ pg_version_old }} main
+
+    - stat: path="/etc/postgresql/{{ pg_version_old }}"
+      register: pg_old_config_dir
+
+    - fail: msg="Wait! The previous action, `pg_dropcluster`, should have removed this."
+      when: pg_old_config_dir.stat.exists
+
+    - name: Vacuum existings databases
+      become: yes
+      become_user: postgres
+      command: >
+        vacuumdb --analyze-only {{ item }}
+      with_items: ['atmo_prod', 'troposphere']
+
+    - name: Remove old PostgreSQL Apt respositories
+      action: >
+        {{ ansible_pkg_mgr }} name={{ item }} state=absent update_cache=yes
+      with_items:
+        - postgresql-{{ pg_version_old }}
+        - postgresql-contrib-{{ pg_version_old }}
+        - postgresql-server-dev-{{ pg_version_old }}
+      when: ansible_distribution == "Ubuntu"

--- a/playbooks/utils/upgrade_postgres.yml
+++ b/playbooks/utils/upgrade_postgres.yml
@@ -49,6 +49,7 @@
         {{ ansible_pkg_mgr }} name={{ item }} state=latest update_cache=yes
       with_items:
         - postgresql-{{ pg_version }}
+        - postgresql-client-{{ pg_version }}
         - postgresql-contrib-{{ pg_version }}
         - postgresql-server-dev-{{ pg_version }}
       tags: ['install', 'upgrade']
@@ -87,12 +88,6 @@
       command: >
         pg_dropcluster --stop {{ pg_version_old }} main
 
-    - stat: path="/etc/postgresql/{{ pg_version_old }}"
-      register: pg_old_config_dir
-
-    - fail: msg="Wait! The previous action, `pg_dropcluster`, should have removed this."
-      when: pg_old_config_dir.stat.exists
-
     - name: Vacuum existings databases
       become: yes
       become_user: postgres
@@ -105,6 +100,13 @@
         {{ ansible_pkg_mgr }} name={{ item }} state=absent update_cache=yes
       with_items:
         - postgresql-{{ pg_version_old }}
+        - postgresql-client-{{ pg_version_old }}
         - postgresql-contrib-{{ pg_version_old }}
         - postgresql-server-dev-{{ pg_version_old }}
       when: ansible_distribution == "Ubuntu"
+
+    - stat: path="/etc/postgresql/{{ pg_version_old }}"
+      register: pg_old_config_dir
+
+    - fail: msg="Wait! The previous action, `pg_dropcluster`, should have removed this."
+      when: pg_old_config_dir.stat.exists

--- a/roles/app-backup-postgres/README.md
+++ b/roles/app-backup-postgres/README.md
@@ -1,0 +1,51 @@
+app-backup-postgres
+===================
+
+Using PostgreSQL executables to dump the contents the database to a single file.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+- `database_names` - list of names of databases (defaults to `[]`)
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+If a specific database within the PostgreSQL server is not identified, a full backup will be made with `pg_dumpall` to a file named off the hostname of the server.
+
+    - hosts: dbservers
+      roles:
+         - { role: app-backup-postgres,
+             tags: ['atmosphere', 'data-backup', 'backup'] }
+
+In addition to a full backup, a single file will be created for foreach string in `database_names`.
+
+    - hosts: dbservers
+      roles:
+         - { role: app-backup-postgres,
+             database_names: ["{{ DBNAME }}"],
+             tags: ['atmosphere', 'data-backup', 'backup'] }
+
+Or, you can list multiple databases by name
+
+    - hosts: dbservers
+      roles:
+        - { role: app-backup-postgres,
+            database_names: ['atmo_prod', 'troposphere'],
+            tags: ['atmosphere', 'data-backup', 'backup'] }
+
+License
+-------
+
+BSD
+

--- a/roles/app-backup-postgres/defaults/main.yml
+++ b/roles/app-backup-postgres/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for app-backup-postgres
+
+database_names: []

--- a/roles/app-backup-postgres/tasks/main.yml
+++ b/roles/app-backup-postgres/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# tasks file for app-backup-postgres
+
+- name: Create "backups" directory
+  file:
+    path: /var/lib/postgresql/backups/{{ ansible_date_time.date }}
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: 0770
+
+- name: Backup all tables (including system tables)
+  become: yes
+  become_user: postgres
+  args:
+    chdir: /var/lib/postgresql/backups/{{ ansible_date_time.date }}
+  command: >
+    pg_dumpall -f "{{ ansible_hostname }}-all-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"
+
+- name: Backup specific tables ({{ database_names }})
+  become: yes
+  become_user: postgres
+  args:
+    chdir: /var/lib/postgresql/backups/{{ ansible_date_time.date }}
+  with_items: "{{ database_names }}"
+  command: >
+    pg_dump {{ item }} -f "{{ ansible_hostname }}-{{ item }}-backup-{{ ansible_date_time.date }}-{{ ansible_date_time.epoch }}.sql"


### PR DESCRIPTION
Addresses Issue #83

This is the first _utility_ playbook defined within Clank. It does not
rely on any of the variables from the various Atmosphere build-env
files used to describe a given installation environment.

It will halt if you have not provided the two require variables:
- `pg_version` (the target to upgrade the server to)
- `pg_version_old` (the existing installation)

Optionally, you can pass a list of database to apply post-install
actions and generate "database-specific" backups:
```
$ clank # ansible-playbook playbooks/utils/upgrade_postgres.yml \
  --flush-cache -c local -i "localhost," \
  -e "{pg_version: '9.5',  pg_version_old: '9.3', database_names: ['atmosphere', 'troposphere']}"
```
Thank you Snehal Parmar for this outline provided on [DBA Stack Exchange](http://dba.stackexchange.com/questions/60465/upgrading-from-postgres-9-1-to-9-3-on-ubuntu-server)