### PR TITLE
Added conditional combined cert generation

### DIFF
--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -87,6 +87,7 @@
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION }}",
         UWSGI_APP_NAME: 'atmosphere',
         UWSGI_INI_SRC_NAME: 'extras/uwsgi/atmo.uwsgi.ini',
+        nginx_vars_context: "{{ ATMO['nginx'] }}",
         tags: ['atmosphere', 'deploy', 'nginx-uwsgi'] }
 
     - { role: setup-webserver-user-group,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -58,6 +58,7 @@
     - { role: config-nginx-uwsgi,
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION }}",
         UWSGI_APP_NAME: 'troposphere',
+        nginx_vars_context: "{{ TROPO['nginx'] }}",
         tags: ['troposphere', 'nginx-uwsgi'] }
 
     - { role: install-airport-ui-assets,

--- a/roles/config-nginx-uwsgi/tasks/main.yml
+++ b/roles/config-nginx-uwsgi/tasks/main.yml
@@ -25,10 +25,35 @@
   - stat: path="{{ nginx_vars_context.COMBINED_CERT_PATH }}"
     register: combined_cert_path
 
+  - name: redefine variables definition for SSL_CERTIFICATE
+    set_fact:
+      nginx_ssl_cert: "{{ nginx_vars_context.CERT_DIR }}/{{ nginx_vars_context.CERT_FILE }}"
+    when: not SSL_CERTIFICATE
+
+  - name: set variables definition from SSL_CERTIFICATE
+    set_fact:
+      nginx_ssl_cert: "{{ SSL_CERTIFICATE }}"
+    when: "{{ SSL_CERTIFICATE is not none }}"
+
+  - name: redefine variable definition for BUNDLE_CERT
+    set_fact:
+      nginx_bundle_cert: "{{ nginx_vars_context.CERT_DIR }}/{{ nginx_vars_context.BUNDLE_FILE }}"
+    when: not BUNDLE_CERT
+
+  - name: set variables definition from BUNDLE_CERT
+    set_fact:
+      nginx_bundle_cert: "{{ BUNDLE_CERT }}"
+    when: "{{ BUNDLE_CERT is not none }}"
+
   - name: generate a combined certificate - {{ nginx_vars_context.COMBINED_CERT_FILE }}
     command: >
-      cat {{ SSL_CERTIFICATE }} {{ BUNDLE_CERT }} > {{ nginx_vars_context.COMBINED_CERT_PATH }}
+      cat {{ nginx_ssl_cert }} {{ nginx_bundle_cert }}
+    register: combined_cert_source
     when: combined_cert_path.stat.exists == False
+
+  - name: local_action copy to - {{ nginx_vars_context.COMBINED_CERT_FILE }}
+    local_action: copy content={{ combined_cert_source.stdout_lines }} dest={{ nginx_vars_context.COMBINED_CERT_PATH }}
+    when: "{{ combined_cert_source.stdout_lines is defined }}"
 
   when: "{{ nginx_vars_context }}"
 

--- a/roles/config-nginx-uwsgi/tasks/main.yml
+++ b/roles/config-nginx-uwsgi/tasks/main.yml
@@ -20,6 +20,18 @@
   tags:
     - deploy
 
+- block:
+
+  - stat: path="{{ nginx_vars_context.COMBINED_CERT_PATH }}"
+    register: combined_cert_path
+
+  - name: generate a combined certificate - {{ nginx_vars_context.COMBINED_CERT_FILE }}
+    command: >
+      cat {{ SSL_CERTIFICATE }} {{ BUNDLE_CERT }} > {{ nginx_vars_context.COMBINED_CERT_PATH }}
+    when: combined_cert_path.stat.exists == False
+
+  when: "{{ nginx_vars_context }}"
+
 - debug: var=output.stdout_lines
   when: "{{ CLANK_VERBOSE | default(False) }}"
 


### PR DESCRIPTION
To specific verify and test this, you can use the _build-env_ from our local vagrant development environments and call the deploy_stack playbook directly:

```
ansible-playbook "/opt/dev/clank/playbooks/deploy_stack.yml" \
  --flush-cache -c local -e "@/vagrant/clank_init/build_env/variables.yml@local" \
  -i "localhost," --tags "nginx-uwsgi" 
```

This will be the scenario for "self-signed" where `SSL_CERTIFICATE` & `BUNDLE_CERT` are empty. 

You can also use the previously created "self-signed" as the values for these variables:

```
ansible-playbook "/opt/dev/clank/playbooks/deploy_stack.yml" \
  --flush-cache -c local -e "@/vagrant/clank_init/build_env/variables.yml@local" \
  -i "localhost," --tags "nginx-uwsgi" 
  -e "{'SSL_CERTIFICATE': '/etc/ssl/certs/self-signed.crt', 'BUNDLE_CERT': '/etc/ssl/certs/self_signed_combined.crt'}"
```
