### PR TITLE
Provide an approach for skipping the output of uWSGI configuration.

### DIFF
--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -1,6 +1,8 @@
 ---
 - name: Setup the Atmosphere API component
   hosts: all
+  vars:
+    production_build: "{{ PRODUCTION_BUILD | default(True) }}"
 
   roles:
     - { role: app-alter-kernel-for-imaging,
@@ -84,6 +86,7 @@
         UWSGI_APP_NAME: 'atmosphere',
         UWSGI_INI_SRC_NAME: 'extras/uwsgi/atmo.uwsgi.ini',
         nginx_vars_context: "{{ ATMO['nginx'] }}",
+        when: production_build,
         tags: ['atmosphere', 'deploy', 'nginx-uwsgi'] }
 
     - { role: setup-webserver-user-group,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -1,6 +1,8 @@
 ---
 - name: Setup the Troposphere UI component
   hosts: all
+  vars:
+    production_build: "{{ PRODUCTION_BUILD | default(True) }}"  
 
   roles:
     - { role: app-config-postgres,
@@ -55,6 +57,7 @@
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION }}",
         UWSGI_APP_NAME: 'troposphere',
         nginx_vars_context: "{{ TROPO['nginx'] }}",
+        when: production_build,
         tags: ['troposphere', 'nginx-uwsgi'] }
 
     - { role: install-airport-ui-assets,


### PR DESCRIPTION
_edited by @lenards_

Jenkins jobs that verify the "deployment" readiness of a branch will currently output to disk a uWSGI ini that has "Jenkins-specific" pathing:
```
[uwsgi]
check-static = /var/lib/jenkins/jobs/Build_Test_Troposphere/workspace/troposphere
chdir = /var/lib/jenkins/jobs/Build_Test_Troposphere/workspace/troposphere
home = /var/lib/jenkins/jobs/Build_Test_Troposphere/workspace/env/troposphere
module = troposphere.wsgi
```

If the build fails, it makes the existing deployment non-functionality. 

Put another way, we would like to _"signal"_ when performing a "build test" versus a "deployment".

Summary of functional problem:
> The Jenkins builds are still creating uwsgi, which causes atmobeta to fail if the deploy step doesn’t work. we should disable this ASAP. The simplest fix requires a var to be set (defaulted to `True`) for it to build, and set to `False`(like jenkins builds).
