### PR TITLE
Fixing default variables in app-load-data-postgres

### DIFF
--- a/roles/app-load-data-postgres/defaults/main.yml
+++ b/roles/app-load-data-postgres/defaults/main.yml
@@ -4,3 +4,11 @@
 POSTGRES_SQL_INSTALL_DIRECTORY: /var/lib/postgresql
 
 TARGET_SQL_LOAD_FILE: "{{ POSTGRES_SQL_INSTALL_DIRECTORY }}/{{ DATABASE_FILE_TO_BE_LOADED | basename }}"
+
+DBNAME:
+
+# boolean variable remains in case it is overridden by a higher precedent
+# (mostly at the `extra_vars` level from a _build-env_ file)
+LOAD_DATABASE: False
+
+DATABASE_FILE_TO_BE_LOADED: # an absolute path to SQL dump file

--- a/roles/app-load-data-postgres/vars/Ubuntu.yml
+++ b/roles/app-load-data-postgres/vars/Ubuntu.yml
@@ -1,2 +1,0 @@
----
-# Ubuntu vars file for app-load-data-postgres

--- a/roles/app-load-data-postgres/vars/main.yml
+++ b/roles/app-load-data-postgres/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for app-load-data-postgres

--- a/roles/app-load-data-postgres/vars/main.yml
+++ b/roles/app-load-data-postgres/vars/main.yml
@@ -1,10 +1,2 @@
 ---
 # vars file for app-load-data-postgres
-
-DBNAME:
-
-# boolean variable remains in case it is overridden by a higher precedent
-# (mostly at the `extra_vars` level from a _build-env_ file)
-LOAD_DATABASE: False
-
-DATABASE_FILE_TO_BE_LOADED: # an absolute path to SQL dump file


### PR DESCRIPTION
Moving variables from vars/main.yml to defaults/main.yml so they have a lower precedence and are overridden by Clank's playbook