### PR TITLE
Removed remaining variable definitions

### DIFF
--- a/roles/app-config-logging/tasks/main.yml
+++ b/roles/app-config-logging/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for app-config-logging
 
-
 - name: create application log directory
   file: path={{ LOG_DIR_BASE }} state=directory
 

--- a/roles/app-config-logging/vars/main.yml
+++ b/roles/app-config-logging/vars/main.yml
@@ -1,5 +1,3 @@
 ---
 # vars file for app-config-logging
 
-APP_BASE_DIR: ""
-LOG_FILES: []

--- a/roles/app-load-data-postgres/tasks/main.yml
+++ b/roles/app-load-data-postgres/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 # tasks file for app-load-data-postgres
 
-- name: gather os specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "defaults.yml"
-  tags: vars
-
 - debug: var=LOAD_DATABASE
   when: "{{ DEBUG_OR_TEST_ROLE | default(False) }}"
 

--- a/roles/setup-postgres/vars/main.yml
+++ b/roles/setup-postgres/vars/main.yml
@@ -1,1 +1,1 @@
-DBUSER: atmosphere_app
+


### PR DESCRIPTION
The update to Ansible >2.0 meant [variable precedence](http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) changed and the
previous approach (plus the parameterization of roles) created some
unexpected "clobbering" (or, clearing - resets of variable values).

This removes the last few definitions.

*Note:* several `vars/main.yml` were left in place to avoid *breaking* :x: any "gather os-specific" variable task(s)