### PR TITLE
Fix failure when `with_first_found` finds nothing to `include_vars`

### DIFF
--- a/roles/app-load-data-postgres/tasks/main.yml
+++ b/roles/app-load-data-postgres/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 # tasks file for app-load-data-postgres
 
-- name: gather os specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "defaults.yml"
-  tags: vars
-
 - debug: var=LOAD_DATABASE
   when: "{{ DEBUG_OR_TEST_ROLE | default(False) }}"
 


### PR DESCRIPTION
The removal of `roles/app-load-data-postgres/vars/` in #113 causes the first task in `roles/app-load-data-postgres/tasks/main.yml` to fail to find a file to _include_ via `include_vars: ... with_first_found` (since there is *nothing* found).

The task I'm referring to is the pattern of "gather os specific" variaables
```
- name: gather os specific variables
  include_vars: "{{ item }}"
  with_first_found:
    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
    - "{{ ansible_distribution }}.yml"
    - "{{ ansible_os_family }}.yml"
    - "defaults.yml"
  tags: vars
```

The *symptom* of this appears like the following:
```
TASK [app-config-postgres : debug] *********************************************
skipping: [localhost]

TASK [app-load-data-postgres : gather os specific variables] *******************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "No file was found when using with_first_found. Use the 'skip: true' option to allow this task to be skipped if no files are found"}

msg: No file was found when using with_first_found. Use the 'skip: true' option to allow this task to be skipped if no files are found

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @/opt/dev/clank/playbooks/deploy_stack.retry

PLAY RECAP *********************************************************************
localhost                  : ok=37   changed=23   unreachable=0    failed=1   

/opt/dev/clank/clank_env/bin/ansible-playbook "/opt/dev/clank/playbooks/deploy_stack.yml" --flush-cache -c local -e "@/vagrant/clank_init/build_env/variables.yml@local" -i "localhost,"
Error Code:2
```