### PR TITLE
Running distro updates before deploying stack

### DIFF
--- a/playbooks/deploy_stack.yml
+++ b/playbooks/deploy_stack.yml
@@ -1,3 +1,4 @@
 ---
+- include: ./prepare_host.yml
 - include: ./deploy_atmosphere.yml
 - include: ./deploy_troposphere.yml

--- a/playbooks/prepare_host.yml
+++ b/playbooks/prepare_host.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure distro is up-to-date
+  hosts: all
+  roles:
+    - distro-update
+  tags:
+    - distro-update

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+
+# Required roles from Ansible Galaxy
+# Install latest version of required Ansible roles by running the following:
+# ansible-galaxy install -f -r requirements.yml -p roles/
+
+- src: CyVerse-Ansible.distro-update
+  name: distro-update

--- a/roles/distro-update/.travis.yml
+++ b/roles/distro-update/.travis.yml
@@ -1,0 +1,63 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: required
+dist: trusty
+services:
+  - docker
+
+env:
+  - distribution: centos
+    version: 7
+    UPDATE_CMD: "'sudo yum update'"
+    NO_UPDATES_MSG: "'No packages marked for update'"
+  - distribution: centos
+    version: 6
+    UPDATE_CMD: "'sudo yum update'"
+    NO_UPDATES_MSG: "'No Packages marked for Update'"
+# No supported/sane way to run Ansible inside a CentOS 5 Docker container;
+#   - distribution: centos
+#     version: 5
+  - distribution: ubuntu
+    version: 16.04
+    UPDATE_CMD: "'sudo apt-get update && sudo apt-get dist-upgrade'"
+    NO_UPDATES_MSG: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.'"
+  - distribution: ubuntu
+    version: 14.04
+    UPDATE_CMD: "'sudo apt-get update && sudo apt-get dist-upgrade'"
+    NO_UPDATES_MSG: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.'"
+  - distribution: ubuntu
+    version: 12.04
+    UPDATE_CMD: "'sudo apt-get update && sudo apt-get dist-upgrade'"
+    NO_UPDATES_MSG: "'0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.'"
+
+before_install:
+  - 'sudo docker run -it --name=test_dummy --privileged --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw cyverse/ansible-test:latest-${distribution}-${version} bash'
+
+script:
+  # Syntax check
+  - "sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --syntax-check"
+
+  # Run playbook to perform updates
+  - "sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local"
+
+  # Run updates manually and confirm that none are applied (i.e. system has been brought up-to-date)
+  - "sudo docker exec test_dummy bash -c \"${UPDATE_CMD}\" > output"
+  - "sudo chmod a+r output"
+  - >
+    grep -q "$NO_UPDATES_MSG" output
+    && (echo 'Test for no updates needed: pass' && exit 0)
+    || (echo 'Test for no updates needed: fail' && exit 1)
+
+  # Idempotence test
+  - >
+    sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+
+notifications:
+    webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/distro-update/README.md
+++ b/roles/distro-update/README.md
@@ -1,0 +1,40 @@
+distro-update
+=========
+
+Runs package manager updates for any systems that use APT or yum.
+
+[![Build Status](https://travis-ci.org/CyVerse-Ansible/ansible-distro-update.svg?branch=master)](https://travis-ci.org/CyVerse-Ansible/ansible-distro-update)
+[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-irods--icommands-blue.svg)](https://galaxy.ansible.com/CyVerse-Ansible/distro-update/)
+
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+    - hosts: all
+      roles:
+         - ansible-distro-update
+
+License
+-------
+
+See license.md
+
+Author Information
+------------------
+
+https://cyverse.org

--- a/roles/distro-update/license.md
+++ b/roles/distro-update/license.md
@@ -1,0 +1,37 @@
+Copyright (c) 2011, The Arizona Board of Regents on behalf of
+The University of Arizona
+
+All rights reserved.
+
+Developed by: iPlant Collaborative as a collaboration between
+participants at BIO5 at The University of Arizona (the primary hosting
+institution), Cold Spring Harbor Laboratory, The University of Texas at
+Austin, and individual contributors. Find out more at
+http://www.iplantcollaborative.org/.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of the iPlant Collaborative, BIO5, The University
+   of Arizona, Cold Spring Harbor Laboratory, The University of Texas at
+   Austin, nor the names of other contributors may be used to endorse or
+   promote products derived from this software without specific prior
+   written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/roles/distro-update/meta/.galaxy_install_info
+++ b/roles/distro-update/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Mon Sep 12 19:21:57 2016', version: master}

--- a/roles/distro-update/meta/main.yml
+++ b/roles/distro-update/meta/main.yml
@@ -1,0 +1,197 @@
+galaxy_info:
+  author: Chris Martin
+  description: Runs package manager updates for both APT and yum
+  company: CyVerse
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: see license.md
+
+  min_ansible_version: 2.X
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Below are all platforms currently available. Just uncomment
+  # the ones that apply to your role. If you don't see your
+  # platform on this list, let us know and we'll get it added!
+  #
+  platforms:
+  - name: EL
+    versions:
+    - all
+    - 5
+    - 6
+    - 7
+  #- name: GenericUNIX
+  #  versions:
+  #  - all
+  #  - any
+  #- name: OpenBSD
+  #  versions:
+  #  - all
+  #  - 5.6
+  #  - 5.7
+  #  - 5.8
+  #  - 5.9
+  #  - 6.0
+  #- name: Fedora
+  #  versions:
+  #  - all
+  #  - 16
+  #  - 17
+  #  - 18
+  #  - 19
+  #  - 20
+  #  - 21
+  #  - 22
+  #  - 23
+  #- name: opensuse
+  #  versions:
+  #  - all
+  #  - 12.1
+  #  - 12.2
+  #  - 12.3
+  #  - 13.1
+  #  - 13.2
+  #- name: MacOSX
+  #  versions:
+  #  - all
+  #  - 10.10
+  #  - 10.11
+  #  - 10.12
+  #  - 10.7
+  #  - 10.8
+  #  - 10.9
+  #- name: IOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Solaris
+  #  versions:
+  #  - all
+  #  - 10
+  #  - 11.0
+  #  - 11.1
+  #  - 11.2
+  #  - 11.3
+  #- name: SmartOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: eos
+  #  versions:
+  #  - all
+  #  - Any
+  #- name: Windows
+  #  versions:
+  #  - all
+  #  - 2012R2
+  #- name: Amazon
+  #  versions:
+  #  - all
+  #  - 2013.03
+  #  - 2013.09
+  #- name: GenericBSD
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Junos
+  #  versions:
+  #  - all
+  #  - any
+  #- name: FreeBSD
+  #  versions:
+  #  - all
+  #  - 10.0
+  #  - 10.1
+  #  - 10.2
+  #  - 10.3
+  #  - 8.0
+  #  - 8.1
+  #  - 8.2
+  #  - 8.3
+  #  - 8.4
+  #  - 9.0
+  #  - 9.1
+  #  - 9.1
+  #  - 9.2
+  #  - 9.3
+  - name: Ubuntu
+    versions:
+  #  - all
+  #  - lucid
+  #  - maverick
+  #  - natty
+  #  - oneiric
+    - precise
+  #  - quantal
+  #  - raring
+  #  - saucy
+    - trusty
+  #  - utopic
+  #  - vivid
+  #  - wily
+    - xenial
+  #- name: SLES
+  #  versions:
+  #  - all
+  #  - 10SP3
+  #  - 10SP4
+  #  - 11
+  #  - 11SP1
+  #  - 11SP2
+  #  - 11SP3
+  #  - 11SP4
+  #  - 12
+  #  - 12SP1
+  #- name: GenericLinux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: NXOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - sid
+  #  - squeeze
+  #  - stretch
+  #  - wheezy
+
+  galaxy_tags:
+    - distro
+    - update
+    - security
+    # List tags for your role here, one per line. A tag is
+    # a keyword that describes and categorizes the role.
+    # Users find roles by searching for tags. Be sure to
+    # remove the '[]' above if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of
+    # alphanumeric characters. Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line.
+  # Be sure to remove the '[]' above if you add dependencies
+  # to this list.

--- a/roles/distro-update/tasks/main.yml
+++ b/roles/distro-update/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: APT
+  apt:
+    update_cache: yes
+    upgrade: dist
+  when: ansible_pkg_mgr == "apt"
+
+- name: Yum
+  yum:
+    update_cache: yes
+    name: "*"
+    state: latest
+  when: ansible_pkg_mgr == "yum"

--- a/roles/distro-update/tests/inventory
+++ b/roles/distro-update/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/distro-update/tests/test.yml
+++ b/roles/distro-update/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - role_under_test


### PR DESCRIPTION
As part of deploying Atmosphere(1), we should ensure that distro-provided packages are up-to-date, especially for security updates. Here, I have added the new [CyVerse-Ansible/distro-update](https://github.com/CyVerse-Ansible/ansible-distro-update) role to perform this, as Clank's first action. I have tested and confirmed that it works in my atmo-local environment.