### PR TITLE
Create a role to automate the backing up of important files

### DIFF
--- a/playbooks/utils/backup_db.yml
+++ b/playbooks/utils/backup_db.yml
@@ -10,7 +10,6 @@
     - debug: msg="Consider passing in `database_names`"
       when: "{{ database_names is undefined or database_names == []}}"
 
-
 - name: Ensure PostgreSQL service available
   hosts: all
 

--- a/playbooks/utils/backup_files.yml
+++ b/playbooks/utils/backup_files.yml
@@ -1,15 +1,4 @@
 ---
-#- name: Checking for necessary --extra_vars
-#  hosts: all
-#  vars:
-#    example:
-#      - "-e \"{database_names: ['atmosphere', 'troposphere']}\""
-#      - "-e \"BACKUP_PATH=/var/lib/postgresql/backups\""
-#  tasks:
-#
-#    - debug: msg="Consider passing in `database_names`"
-#      when: "{{ database_names is undefined or database_names == []}}"
-
 - name: Backup all files
   hosts: all
 

--- a/playbooks/utils/backup_files.yml
+++ b/playbooks/utils/backup_files.yml
@@ -1,0 +1,18 @@
+---
+#- name: Checking for necessary --extra_vars
+#  hosts: all
+#  vars:
+#    example:
+#      - "-e \"{database_names: ['atmosphere', 'troposphere']}\""
+#      - "-e \"BACKUP_PATH=/var/lib/postgresql/backups\""
+#  tasks:
+#
+#    - debug: msg="Consider passing in `database_names`"
+#      when: "{{ database_names is undefined or database_names == []}}"
+
+- name: Backup all files
+  hosts: all
+
+  roles:
+    - { role: app-backup-files,
+        tags: ['data-backup', 'backup', 'files'] }

--- a/playbooks/utils/perform_backup.yml
+++ b/playbooks/utils/perform_backup.yml
@@ -1,0 +1,3 @@
+---
+- include: ./backup_files.yml
+- include: ./backup_db.yml

--- a/roles/app-backup-files/README.md
+++ b/roles/app-backup-files/README.md
@@ -49,10 +49,45 @@ None.
 Example Playbook
 ----------------
 
+Example using default variables:
+
     - hosts: all
       roles:
          - { role: app-backup-files,
              tags: ['data-backup', 'backup', 'files'] }
+
+Example defining an alternative back up location:
+
+    - hosts: all
+      roles:
+         - { role: app-backup-files,
+             BACKUP_PATH: /root/backups_are_important,
+             tags: ['data-backup', 'backup', 'files'] }
+
+Example defining a collection of files to be backed up:
+
+    - hosts: all
+      vars:
+        MY_BACKUPS:
+            # Copy out Atmosphere specific confs
+            - NAME: atmosphere
+            PROJECT_NAME: atmo
+            FILES:
+              - /opt/dev/atmosphere/variables.ini
+              - /opt/dev/atmosphere/atmosphere/settings/local.py
+
+            # Copy out troposphere specific conf
+            - NAME: troposphere
+            PROJECT_NAME: tropo
+            FILES:
+              - /opt/dev/troposphere/variables.ini
+
+      roles:
+         - { role: app-backup-files,
+             LIST_OF_BACKUPS : MY_BACKUPS, 
+             tags: ['data-backup', 'backup', 'files'] }
+
+This will create a backup directory containing two dirs (atmo, tropo). Each of those dirs will contain their respective files for safe keeping.  
 
 License
 -------

--- a/roles/app-backup-files/README.md
+++ b/roles/app-backup-files/README.md
@@ -1,0 +1,60 @@
+app-backup-postgres
+===================
+
+Using PostgreSQL executables to dump the contents the database to a single file.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+- `database_names` - list of names of databases (defaults to `[]`)
+- 'BACKUP_PATH' - a path that resides underneath the postgres user owernship
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+If a specific database within the PostgreSQL server is not identified, a full backup will be made with `pg_dumpall` to a file named off the hostname of the server.
+
+    - hosts: dbservers
+      roles:
+         - { role: app-backup-postgres,
+             tags: ['atmosphere', 'data-backup', 'backup'] }
+
+In addition to a full backup, a single file will be created for foreach string in `database_names`.
+
+    - hosts: dbservers
+      roles:
+         - { role: app-backup-postgres,
+             database_names: ["{{ DBNAME }}"],
+             tags: ['atmosphere', 'data-backup', 'backup'] }
+
+Or, you can list multiple databases by name
+
+    - hosts: dbservers
+      roles:
+        - { role: app-backup-postgres,
+            database_names: ['atmo_prod', 'troposphere'],
+            tags: ['atmosphere', 'data-backup', 'backup'] }
+
+Specifing a path for the dumps to be save to. Be sure that path given resides under the postgresql's owernship
+
+    - hosts: dbservers
+      roles:
+        - { role: app-backup-postgres,
+            BACKUP_PATH: /var/lib/postgresql/backups_are_important
+            database_names: ['atmo_prod', 'troposphere'],
+            tags: ['atmosphere', 'data-backup', 'backup'] }
+
+License
+-------
+
+BSD
+

--- a/roles/app-backup-files/README.md
+++ b/roles/app-backup-files/README.md
@@ -1,7 +1,7 @@
-app-backup-postgres
+app-backup-files
 ===================
 
-Using PostgreSQL executables to dump the contents the database to a single file.
+Using a nested list data structure, dump the files in said data structure to a remote directory as a backup.
 
 Requirements
 ------------
@@ -10,9 +10,37 @@ None.
 
 Role Variables
 --------------
+- `BACKUP_PATH`     - Path of where you want the backedup files dumped to    
+- `LIST_OF_BACKUPS` - List of lists that contains files along with a name of the project they belong to.
 
-- `database_names` - list of names of databases (defaults to `[]`)
-- 'BACKUP_PATH' - a path that resides underneath the postgres user owernship
+    An example of the variable:
+  
+    LIST_OF_BACKUPS:
+      # Copy out Atmosphere specific confs
+      - NAME: atmosphere
+        PROJECT_NAME: atmo
+        FILES:
+            - /opt/dev/atmosphere/variables.ini
+            - /opt/dev/atmosphere/atmosphere/settings/local.py
+            - /opt/dev/atmosphere/atmosphere/settings/secrets.py
+
+        # Copy out troposphere specific conf
+      - NAME: troposphere
+        PROJECT_NAME: tropo
+        FILES:
+          - /opt/dev/troposphere/variables.ini
+          - /opt/dev/troposphere/package.json
+          - /opt/dev/troposphere/troposphere/settings/local.py
+
+        # Copy out nginx/uswgi confs
+      - NAME: web_confs
+        PROJECT_NAME: web_confs
+        FILES:
+          - /etc/nginx/sites-enabled
+          - /etc/nginx/locations
+          - /etc/uwsgi/apps-enabled
+          - /etc/default/celeryd  
+
 Dependencies
 ------------
 
@@ -21,40 +49,12 @@ None.
 Example Playbook
 ----------------
 
-If a specific database within the PostgreSQL server is not identified, a full backup will be made with `pg_dumpall` to a file named off the hostname of the server.
-
-    - hosts: dbservers
+    - hosts: all
       roles:
-         - { role: app-backup-postgres,
-             tags: ['atmosphere', 'data-backup', 'backup'] }
-
-In addition to a full backup, a single file will be created for foreach string in `database_names`.
-
-    - hosts: dbservers
-      roles:
-         - { role: app-backup-postgres,
-             database_names: ["{{ DBNAME }}"],
-             tags: ['atmosphere', 'data-backup', 'backup'] }
-
-Or, you can list multiple databases by name
-
-    - hosts: dbservers
-      roles:
-        - { role: app-backup-postgres,
-            database_names: ['atmo_prod', 'troposphere'],
-            tags: ['atmosphere', 'data-backup', 'backup'] }
-
-Specifing a path for the dumps to be save to. Be sure that path given resides under the postgresql's owernship
-
-    - hosts: dbservers
-      roles:
-        - { role: app-backup-postgres,
-            BACKUP_PATH: /var/lib/postgresql/backups_are_important
-            database_names: ['atmo_prod', 'troposphere'],
-            tags: ['atmosphere', 'data-backup', 'backup'] }
+         - { role: app-backup-files,
+             tags: ['data-backup', 'backup', 'files'] }
 
 License
 -------
 
 BSD
-

--- a/roles/app-backup-files/defaults/main.yml
+++ b/roles/app-backup-files/defaults/main.yml
@@ -27,4 +27,4 @@ LIST_OF_BACKUPS:
       - /etc/nginx/sites-enabled
       - /etc/nginx/locations
       - /etc/uwsgi/apps-enabled
-      #- /etc/default/celeryd
+      - /etc/default/celeryd

--- a/roles/app-backup-files/defaults/main.yml
+++ b/roles/app-backup-files/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# defaults file for app-backup-postgres
+
+BACKUP_PATH: /root/atmo_backups
+
+LIST_OF_BACKUPS:
+    # Copy out Atmosphere specific confs
+  - NAME: atmosphere
+    PROJECT_NAME: atmo
+    FILES:
+        - /opt/dev/atmosphere/variables.ini
+        - /opt/dev/atmosphere/atmosphere/settings/local.py
+        - /opt/dev/atmosphere/atmosphere/settings/secrets.py
+   
+    # Copy out troposphere specific conf
+  - NAME: troposphere
+    PROJECT_NAME: tropo
+    FILES:
+      - /opt/dev/troposphere/variables.ini
+      - /opt/dev/troposphere/package.json
+      - /opt/dev/troposphere/troposphere/settings/local.py
+
+    # Copy out nginx/uswgi confs
+  - NAME: web_confs
+    PROJECT_NAME: web_confs
+    FILES:
+      - /etc/nginx/sites-enabled
+      - /etc/nginx/locations
+      - /etc/uwsgi/apps-enabled
+      #- /etc/default/celeryd

--- a/roles/app-backup-files/tasks/main.yml
+++ b/roles/app-backup-files/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for app-backup-postgres
+
+- name: Create "backups" directory
+  file:
+    path: "{{ BACKUP_PATH }}/{{ ansible_date_time.date }}/{{ item.PROJECT_NAME }}"
+    state: directory
+    mode: 0770
+  with_items: LIST_OF_BACKUPS
+    
+  # The following task is helpful for copying the backup directory to a location that the postgresql user normally can't copy to
+- name: Copy backup to specific location
+  command: cp -r {{ item.1 }} {{ BACKUP_PATH }}/{{ ansible_date_time.date }}/{{ item.0.PROJECT_NAME }}
+  with_subelements:
+    - LIST_OF_BACKUPS
+    - FILES


### PR DESCRIPTION
This PR is to hopefully eliminate the tedious deployment day task of backing up tedious files. Specifically I want to remove these steps from deployment day:

```
cd /root/atmo_backups/date +%Y_%m_%d`

# Copy out Atmosphere specific confs
cp /opt/dev/atmosphere/variables.ini .
cp /opt/dev/atmosphere/atmosphere/settings/local.py .
cp /opt/dev/atmosphere/atmosphere/settings/secrets.py .
# Copy out troposphere specific conf
cp /opt/dev/troposphere/variables.ini .
cp /opt/dev/troposphere/package.json .
cp /opt/dev/troposphere/troposphere/settings/local.py .
# Copy out nginx/uswgi conf   
cp /etc/nginx/sites-enabled/* .
cp /etc/nginx/locations/* .
cp /etc/uwsgi/apps-enabled/* .
cp /etc/default/celeryd .
```

The role requires two variables. The `BACKUP_PATH` variable defines a location of where to save the backups to, containing a dir named after a date stamp.
```
BACKUP_PATH: /root/atmo_backups
```
By creating a data structure as the one below:
```
LIST_OF_BACKUPS:
    # Copy out Atmosphere specific confs
  - NAME: atmosphere
    PROJECT_NAME: atmo
    FILES:
        - /opt/dev/atmosphere/variables.ini
        - /opt/dev/atmosphere/atmosphere/settings/local.py
        - /opt/dev/atmosphere/atmosphere/settings/secrets.py

    # Copy out troposphere specific conf
  - NAME: troposphere
    PROJECT_NAME: tropo
    FILES:
      - /opt/dev/troposphere/variables.ini
      - /opt/dev/troposphere/package.json
      - /opt/dev/troposphere/troposphere/settings/local.py

    # Copy out nginx/uswgi confs
  - NAME: web_confs
    PROJECT_NAME: web_confs
    FILES:
      - /etc/nginx/sites-enabled
      - /etc/nginx/locations
      - /etc/uwsgi/apps-enabled
      - /etc/default/celeryd
```
we are left with a backup folder structure:
```
atmo_backups/
└── 2016-09-14
    ├── atmo
    │   ├── local.py
    │   ├── secrets.py
    │   └── variables.ini
    ├── troposphere
    │   ├── local.py
    │   ├── package.json
    │   └── variables.ini
    └── web_confs
        ├── apps-enabled
        │   ├── d
        │   ├── e
        │   └── f
        ├── locations
        │   ├── b
        │   └── c
        └── sites-enabled
            └── a

```

As result of this PR and PR [121](https://github.com/iPlantCollaborativeOpenSource/clank/pull/121), we can hopefully skip step 1 from the [release day instructions](https://docs.google.com/document/d/1NkflIfQcwtl677b_sLR6viPwkCWChZ1kgDvVrKAMNuo/edit).