### PR TITLE
Add util playbook to create release virtualenvs

### DIFF
--- a/playbooks/utils/create_release_virtualenvs.yml
+++ b/playbooks/utils/create_release_virtualenvs.yml
@@ -1,0 +1,41 @@
+---
+- name: Checking for necessary --extra_vars
+  hosts: all
+  vars:
+    example:
+      - "-e RELEASE_INITIALS=rr"
+
+  tasks:
+
+    - fail: msg="\nMust set RELEASE_INITIALS.\nPass a value in via {{ example[0] }}"
+      when: "{{ RELEASE_INITIALS is undefined }}"
+
+
+- name: Setup virtualenv for atmo
+  hosts: all
+
+  roles:
+    - { role: setup-virtualenv,
+        VIRTUAL_ENV_NAME: "{{ atmosphere_virtualenv_name | default('atmo') }}_{{ RELEASE_INITIALS }}",
+        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir | default('/opt/env') }}"
+      }
+
+- name: create link /opt/env/atmo to new atmo {{ RELEASE_INITIALS }} repo
+  hosts: all
+
+  tasks: 
+    - command: ln -snf {{ atmosphere_virtualenv_name | default('atmo') }}_{{ RELEASE_INITIALS }} /opt/env/atmo
+
+- name: setup virtualenv for tropo
+  hosts: all
+
+  roles:
+    - { role: setup-virtualenv,
+        VIRTUAL_ENV_NAME: "{{ troposphere_virtualenv_name | default('tropo') }}_{{ RELEASE_INITIALS }}",
+        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir | default('/opt/env') }}"
+      } 
+
+- name: create link /opt/env/troposphere to new tropo {{ RELEASE_INITIALS }} repo
+  hosts: all
+  tasks:
+    - command: ln -snf {{ troposphere_virtualenv_name | default('tropo') }}_{{ RELEASE_INITIALS }} /opt/env/troposphere

--- a/playbooks/utils/create_release_virtualenvs.yml
+++ b/playbooks/utils/create_release_virtualenvs.yml
@@ -1,41 +1,36 @@
 ---
 - name: Checking for necessary --extra_vars
-  hosts: all
+  hosts: atmosphere
   vars:
     example:
       - "-e RELEASE_INITIALS=rr"
-
   tasks:
 
     - fail: msg="\nMust set RELEASE_INITIALS.\nPass a value in via {{ example[0] }}"
       when: "{{ RELEASE_INITIALS is undefined }}"
 
-
 - name: Setup virtualenv for atmo
-  hosts: all
-
+  hosts: atmosphere
   roles:
     - { role: setup-virtualenv,
-        VIRTUAL_ENV_NAME: "{{ atmosphere_virtualenv_name | default('atmo') }}_{{ RELEASE_INITIALS }}",
-        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir | default('/opt/env') }}"
+        VIRTUAL_ENV_NAME: "{{ atmosphere_virtualenv_path }}_{{ RELEASE_INITIALS }}",
+        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir }}"
       }
 
 - name: create link /opt/env/atmo to new atmo {{ RELEASE_INITIALS }} repo
-  hosts: all
-
+  hosts: atmosphere
   tasks: 
-    - command: ln -snf {{ atmosphere_virtualenv_name | default('atmo') }}_{{ RELEASE_INITIALS }} /opt/env/atmo
+    - command: ln -snf {{ atmosphere_virtualenv_path }}_{{ RELEASE_INITIALS }} /opt/env/atmo
 
 - name: setup virtualenv for tropo
-  hosts: all
-
+  hosts: troposphere
   roles:
     - { role: setup-virtualenv,
-        VIRTUAL_ENV_NAME: "{{ troposphere_virtualenv_name | default('tropo') }}_{{ RELEASE_INITIALS }}",
-        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir | default('/opt/env') }}"
+        VIRTUAL_ENV_NAME: "{{ troposphere_virtualenv_path }}_{{ RELEASE_INITIALS }}",
+        VIRTUAL_ENV_BASE_DIR: "{{ virtualenv_dir }}"
       } 
 
 - name: create link /opt/env/troposphere to new tropo {{ RELEASE_INITIALS }} repo
-  hosts: all
+  hosts: troposphere
   tasks:
-    - command: ln -snf {{ troposphere_virtualenv_name | default('tropo') }}_{{ RELEASE_INITIALS }} /opt/env/troposphere
+    - command: ln -snf {{ troposphere_virtualenv_path }}_{{ RELEASE_INITIALS }} /opt/env/troposphere


### PR DESCRIPTION
This util playbook is to be run before release deployment. It creates python virtualenvs that are named based on the release abbreviations. The playbook requires a variable to be passed in, e.g. `-e RELEASE_INITIALS=rr`.

This should save us a few more minutes on deployment day.

  