### PR TITLE
Add required variables for MAINTENANCE_EXEMPT_USERNAMES

### DIFF
--- a/group_vars/atmosphere
+++ b/group_vars/atmosphere
@@ -149,6 +149,7 @@ ATMO:
         SUPPORT_EMAIL: "{{ SUPPORT_EMAIL | default('') }}"
         SUPPORT_EMAIL_SIGNATURE: "{{ SUPPORT_EMAIL_SIGNATURE | default('') }}"
         SUPPORT_LINKS: "{{ SUPPORT_LINKS | default('') }}"
+        MAINTENANCE_EXEMPT_USERNAMES: "{{ maintenance_exempt_usernames }}"
         MONTHLY_RESET_PROVIDER_LOCATIONS: "{{ MONTHLY_RESET_PROVIDER_LOCATIONS | default('') }}"
         REPLICATION_PROVIDER_LOCATION: "{{ REPLICATION_PROVIDER_LOCATION | default('') }}"
         EMAIL_LOOKUP_METHOD: "{{ EMAIL_LOOKUP_METHOD | default('djangoLookupEmail') }}"

--- a/group_vars/common
+++ b/group_vars/common
@@ -12,3 +12,5 @@ nginx_combined_cert_path: "{{nginx_combined_cert_dir}}/{{nginx_combined_cert_fil
 nginx_key_dir: /etc/ssl/private
 nginx_key_file: atmo_ssl_cert.key
 nginx_key_path: "{{nginx_key_dir}}/{{nginx_key_file}}"
+staff_list_usernames: "{{ STAFF_LIST_USERNAMES | default([]) }}"
+maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_list_usernames) }}"

--- a/group_vars/troposphere
+++ b/group_vars/troposphere
@@ -105,7 +105,8 @@ TROPO:
         OAUTH_CLIENT_SECRET: "{{ TROPO_OAUTH_CLIENT_SECRET | default('') }}"
         OAUTH_CLIENT_CALLBACK: "{{ CAS_OAUTH_CLIENT_CALLBACK | default('') }}"
 
-        STAFF_LIST_USERNAMES: "{{ STAFF_LIST_USERNAMES | default([]) }}"
+        STAFF_LIST_USERNAMES: "{{ maintenance_exempt_usernames }}"
+        MAINTENANCE_EXEMPT_USERNAMES: "{{ maintenance_exempt_usernames }}"
 
         BADGES_ENABLED: "{{ BADGES_ENABLED | default(False) }}"
         BADGE_SECRET: "{{ BADGE_SECRET | default('') }}"


### PR DESCRIPTION
To avoid compatibility errors, also allow variables files to define either STAFF_LIST_USERNAMES (old) or MAINTENANCE_EXEMPT_USERNAMES to fill out the required variables.

Atmosphere PR: https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/207
Troposphere PR: https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/475
Clank PR: https://github.com/iPlantCollaborativeOpenSource/clank/pull/130