### PR TITLE
Faster dev environment rebuilds

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,6 +8,7 @@
 # finds first
 
 [defaults]
+callback_whitelist = profile_tasks
 
 # some basic default values...
 
@@ -214,5 +215,3 @@ accelerate_daemon_timeout = 30
 # have access to the system via SSH to add a new key. The default
 # is "no".
 #accelerate_multi_key = yes
-
-callback_whitelist = profile_tasks

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,8 @@
 # the home directory or /etc/ansible/ansible.cfg, whichever it
 # finds first
 
+callback_whitelist = profile_tasks
+
 [defaults]
 
 # some basic default values...
@@ -214,4 +216,3 @@ accelerate_daemon_timeout = 30
 # have access to the system via SSH to add a new key. The default
 # is "no".
 #accelerate_multi_key = yes
-

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,8 +7,6 @@
 # the home directory or /etc/ansible/ansible.cfg, whichever it
 # finds first
 
-callback_whitelist = profile_tasks
-
 [defaults]
 
 # some basic default values...
@@ -216,3 +214,5 @@ accelerate_daemon_timeout = 30
 # have access to the system via SSH to add a new key. The default
 # is "no".
 #accelerate_multi_key = yes
+
+callback_whitelist = profile_tasks

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -237,7 +237,7 @@ AUTH_MOCK_USER: "atmosphere_user"
 # atmosphere_ansible_github_repo: https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible.git
 
 ###############################
-#5. Overrides for Clank Execition
+#5. Overrides for Clank Execution
 ###############################
 # Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
 # faster_dev_rebuild: true

--- a/dist_files/variables.yml.dist
+++ b/dist_files/variables.yml.dist
@@ -235,3 +235,9 @@ AUTH_MOCK_USER: "atmosphere_user"
 
 #Specific overrides of group_vars/atmosphere-ansible go here:
 # atmosphere_ansible_github_repo: https://github.com/iPlantCollaborativeOpenSource/atmosphere-ansible.git
+
+###############################
+#5. Overrides for Clank Execition
+###############################
+# Uncomment for faster Clank run (you will not get very latest packages, do not use in production!)
+# faster_dev_rebuild: true

--- a/group_vars/common
+++ b/group_vars/common
@@ -14,3 +14,4 @@ nginx_key_file: atmo_ssl_cert.key
 nginx_key_path: "{{nginx_key_dir}}/{{nginx_key_file}}"
 staff_list_usernames: "{{ STAFF_LIST_USERNAMES | default([]) }}"
 maintenance_exempt_usernames: "{{ MAINTENANCE_EXEMPT_USERNAMES | default(staff_list_usernames) }}"
+faster_dev_rebuild: false

--- a/playbooks/prepare_host.yml
+++ b/playbooks/prepare_host.yml
@@ -3,5 +3,6 @@
   hosts: all
   roles:
     - distro-update
+  when: faster_dev_rebuild == False
   tags:
     - distro-update

--- a/playbooks/prepare_host.yml
+++ b/playbooks/prepare_host.yml
@@ -2,7 +2,7 @@
 - name: Ensure distro is up-to-date
   hosts: all
   roles:
-    - distro-update
-  when: faster_dev_rebuild == False
+    - role: distro-update
+      when: faster_dev_rebuild == False
   tags:
     - distro-update

--- a/playbooks/setup_atmosphere.yml
+++ b/playbooks/setup_atmosphere.yml
@@ -29,7 +29,7 @@
         APP_BASE_DIR: "{{ ATMOSPHERE_LOCATION | default(atmosphere_directory_path) }}",
         REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_ATMOSPHERE | default(atmosphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '--no-cache-dir --no-binary pycparser',
+        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['atmosphere', 'pip-install-requirements']}
 
     - { role: app-config-logging,

--- a/playbooks/setup_troposphere.yml
+++ b/playbooks/setup_troposphere.yml
@@ -25,7 +25,7 @@
         APP_BASE_DIR: "{{ TROPOSPHERE_LOCATION | default(troposphere_directory_path) }}",
         REQUIREMENTS_FILE_NAME: 'dev_requirements.txt',
         VIRTUAL_ENV: "{{ VIRTUAL_ENV_TROPOSPHERE | default(troposphere_virtualenv_path) }}",
-        PIP_EXTRA_ARGS: '--no-cache-dir --no-binary pycparser',
+        PIP_EXTRA_ARGS: '{% if faster_dev_rebuild == false %}--no-cache-dir {% endif %}--no-binary pycparser',
         tags: ['troposphere', 'pip-install-requirements']}
 
     - { role: app-config-logging,

--- a/playbooks/utils/install_novnc_auth.yml
+++ b/playbooks/utils/install_novnc_auth.yml
@@ -187,6 +187,7 @@
       git:
         repo: "https://github.com/cyverse/nginx_novnc_auth.git"
         dest: "/tmp/clank/nginx_novnc_auth"
+        depth: 1
 
 
 - name: Locally render templates for nginx_novnc_auth

--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -1,6 +1,8 @@
 - name: clone git repo with branched defined
-  git: repo={{ REPO_URI }}
-       dest={{ CLONE_TARGET }}
-       clone=yes
-       update=yes
-       version={{ SPECIFIC_BRANCH | default("master", true) }}
+  git:
+    repo: "{{ REPO_URI }}"
+    dest: "{{ CLONE_TARGET }}"
+    clone: yes
+    depth: 1
+    update: yes
+    version: "{{ SPECIFIC_BRANCH | default("master", true) }}"

--- a/roles/clone-repo/tasks/main.yml
+++ b/roles/clone-repo/tasks/main.yml
@@ -5,4 +5,4 @@
     clone: yes
     depth: 1
     update: yes
-    version: "{{ SPECIFIC_BRANCH | default("master", true) }}"
+    version: "{{ SPECIFIC_BRANCH | default('master', true) }}"

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -32,7 +32,6 @@
   apt: update_cache=yes
   when:
     - ansible_distribution == "Ubuntu"
-    - faster_dev_rebuild == false
   tags: apt-install
 
 - name: install initial packages

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -13,12 +13,6 @@
   service: name={{ APACHE }} state=stopped enabled=no
   failed_when: False
 
-- name: install initial packages
-  action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state=latest update_cache=yes
-  with_items: "{{ INITIAL_PACKAGES.packages }}"
-  tags: install, apt-install
-
 - name: remove old apt respositories
   apt_repository: repo={{ item }} state=absent
   with_items: "{{ APT_REPOSITORIES_TO_REMOVE.packages }}"
@@ -27,17 +21,25 @@
 - name: add apt keys
   apt_key: file={{ item }} state=present
   with_items: "{{ APT_KEYS_TO_ADD.packages }}"
-  when: ansible_distribution == "Ubuntu" 
+  when: ansible_distribution == "Ubuntu"
 
 - name: add apt repositories
   apt_repository: repo={{ item }} state=present
   with_items: "{{ APT_REPOSITORIES_TO_ADD.packages }}"
-  when: ansible_distribution == "Ubuntu" 
+  when: ansible_distribution == "Ubuntu"
 
 - name: update cache as a separate step
   apt: update_cache=yes
-  when: ansible_distribution == "Ubuntu"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - faster_dev_rebuild == false
   tags: apt-install
+
+- name: install initial packages
+  action: >
+    {{ ansible_pkg_mgr }} name={{ item }} state=latest update_cache=no
+  with_items: "{{ INITIAL_PACKAGES.packages }}"
+  tags: install, apt-install
 
 - name: install dev packages
   action: >


### PR DESCRIPTION
The goal is to reduce the tweak/rebuild/test cycle time for developers using Clank with the [atmo-local](https://gitlab.cyverse.org/atmosphere/atmo-local) environment. Basically, you set `faster_dev_rebuild` to `true` when you want your development environment to rebuild much more quickly, at the expense of maybe getting slightly older dependencies.

Benchmarking on my laptop, the first run (with no existing caches) takes about 26 minutes, but after the caches are populated, subsequent complete rebuilds (destroying and re-creating the Vagrant VM) take about 10 minutes.

When `faster_dev_rebuild` is set to true, Clank skips the full update of all distro packages and uses the local PIP cache for installing Python dependencies. When used with [atmo-local](https://gitlab.cyverse.org/atmosphere/atmo-local), APT, PIP, and NPM packages are cached outside the vagrant VM and retained between rebuilds.

See also the companion [merge request in atmo-local](https://gitlab.cyverse.org/atmosphere/atmo-local/merge_requests/2).

Additionally:
- Clank performs shallow clones of git repositories to save time and bandwidth
- I removed what I think is a redundant `apt-get update` in the install-dependencies role
- Ansible does task profiling; at the end of the Clank run, Ansible shows you which took the longest, to identify opportinities for future optimizations. Check it out:

```
PLAY RECAP *********************************************************************
localhost                  : ok=151  changed=86   unreachable=0    failed=0   

Tuesday 01 November 2016  19:05:04 +0000 (0:00:00.027)       0:09:21.666 ****** 
=============================================================================== 
build-install-troposphere-ui-assets : run npm install ----------------- 166.58s
build-install-troposphere-ui-assets : run npm build -------------------- 75.04s
clone-repo : clone git repo with branched defined ---------------------- 61.22s
install-dependencies : add apt repositories ---------------------------- 45.41s
app-django-manage-migrate : django manage migrate ---------------------- 44.75s
```

Thanks to @julianpistorius for the initial idea and much of this work.