### PR TITLE
Allow uwsgi communication with ports instead of unix sockets

### DIFF
--- a/playbooks/deploy_atmosphere.yml
+++ b/playbooks/deploy_atmosphere.yml
@@ -100,4 +100,5 @@
         APP_MODULE: "atmosphere.wsgi",
         NUM_PROCESSES: "{{ atmosphere_uwsgi_processes | default(16) }}",
         AUTORELOAD: "{{ UWSGI_AUTORELOAD | default(false) }}",
+        APP_SOCK: "{{ ATMO_APP_SOCK | default('/tmp/' + APP_NAME + '.sock') }}",
         tags: ['atmosphere', 'uwsgi'] }

--- a/playbooks/deploy_troposphere.yml
+++ b/playbooks/deploy_troposphere.yml
@@ -82,4 +82,5 @@
         APP_WORKER_MAX_CONCURRENT_REQUESTS: 100,
         NUM_PROCESSES: "{{ troposphere_uwsgi_processes | default(16) }}",
         AUTORELOAD: "{{ UWSGI_AUTORELOAD | default(false) }}",
+        APP_SOCK: "{{ TROPO_APP_SOCK | default('/tmp/' + APP_NAME + '.sock') }}",
         tags: ['troposphere', 'uwsgi' ] }

--- a/roles/configure-nginx/defaults/main.yml
+++ b/roles/configure-nginx/defaults/main.yml
@@ -12,5 +12,5 @@ LOCATIONS_DIR: /etc/nginx/locations
 SNIPPETS_DIR: /etc/nginx/snippets
 ALTERNATE_SERVER_NAMES: []
 
-TROPO_UWSGI_SOCK: /tmp/troposphere.sock
-ATMO_UWSGI_SOCK: /tmp/atmosphere.sock
+TROPO_UWSGI_SOCK: unix:///tmp/troposphere.sock
+ATMO_UWSGI_SOCK: unix:///tmp/atmosphere.sock

--- a/roles/configure-nginx/templates/atmo-uwsgi.conf.j2
+++ b/roles/configure-nginx/templates/atmo-uwsgi.conf.j2
@@ -5,5 +5,5 @@ location / {
    }
    include {{ SNIPPETS_DIR }}/uwsgi_params;
    uwsgi_read_timeout 300;
-   uwsgi_pass unix://{{ ATMO_UWSGI_SOCK }};
+   uwsgi_pass {{ ATMO_UWSGI_SOCK }};
 }

--- a/roles/configure-nginx/templates/tropo-uwsgi.conf.j2
+++ b/roles/configure-nginx/templates/tropo-uwsgi.conf.j2
@@ -2,10 +2,10 @@ location ~^/(application|maintenance|login|globus_login|oauth2.0/callbackAuthori
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     include {{ SNIPPETS_DIR }}/uwsgi_params;
-    uwsgi_pass unix://{{ TROPO_UWSGI_SOCK }};
+    uwsgi_pass {{ TROPO_UWSGI_SOCK }};
 }
 
 location ~^/cas/(oauth2.0|service) {
     include {{ SNIPPETS_DIR }}/uwsgi_params;
-    uwsgi_pass unix://{{ TROPO_UWSGI_SOCK }};
+    uwsgi_pass {{ TROPO_UWSGI_SOCK }};
 }

--- a/roles/configure-uwsgi/templates/app.ini.j2
+++ b/roles/configure-uwsgi/templates/app.ini.j2
@@ -6,7 +6,7 @@ module = {{ APP_MODULE }}
 {% for VAR_DECL in APP_ENV_VARS | default([]) %}
 env = {{ VAR_DECL }}
 {% endfor %}
-socket = {{ APP_SOCK | default('/tmp/' + APP_NAME + '.sock') }}
+socket = {{ APP_SOCK }}
 processes = {{ NUM_PROCESSES | default('16') }}
 uid = {{ USER | default('www-data') }}
 gid = {{ GROUP | default('www-data') }}


### PR DESCRIPTION
## Description

This PR will allow me to run atmosphere-docker without a shared `/tmp` volume for unix sockets.

This adds new variables: `ATMO_APP_SOCK` and `TROPO_APP_SOCK` which are the *internal* socket addresses for uwsgi configuration.

It uses existing variables: `ATMO_UWSGI_SOCK` and `TROPO_UWSGI_SOCK` which are the *external* addresses seen/used by nginx. Or more generally, it allows us to run Atmosphere, Troposphere, and Nginx on different hosts if we want to.

If these variables are not defined, Clank behavior is unchanged and unix sockets are used so this change only requires extra variables in atmosphere-docker or other deployments that would prefer ports over unix sockets.

---

#### Bonus info

In the case where troposphere, atmosphere, and nginx are all on the same host, `ATMO_APP_SOCK` would be the same as `ATMO_UWSGI_SOCK` (also true for troposphere versions of the variables).

For the curious, Atmosphere Docker will use:
```
ATMO_UWSGI_SOCK: "atmosphere:8080"
TROPO_UWSGI_SOCK: "127.0.0.1:8081"

ATMO_APP_SOCK: "0.0.0.0:8080"
TROPO_APP_SOCK: "127.0.0.1:8081"
```

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Updated CHANGELOG.md
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables committed to secrets repos
